### PR TITLE
fix: exclude test-results and .crt from releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,13 +30,15 @@ npm-debug.log*
 # Package lock (keep package-lock.json for reproducible builds)
 # package-lock.json
 
-# Test coverage
+# Test coverage & results
 coverage/
+test-results/
 .phpunit.result.cache
 .phpunit.cache/
 
 # Nextcloud
 appinfo/signature.json
+appinfo/*.crt
 
 # Release artifacts
 *.tar.gz


### PR DESCRIPTION
## Summary
- Adds `test-results/` and `appinfo/*.crt` to `.gitignore`
- Fixes integrity check failures on Nextcloud instances after App Store install

## Context
v0.4.0 tarballs contained extra files (`appinfo/worktime.crt`, `test-results/.last-run.json`) that are not covered by the app signature, causing integrity warnings for all users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)