### PR TITLE
chore: sync main v0.4.1 back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-11
+
+### Fixed
+- Integritaetspruefung: `test-results/` und `appinfo/*.crt` aus Tarball entfernt
+
 ## [0.4.0] - 2026-04-11
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Gesetzeskonforme Arbeitszeiterfassung für kleine Unternehmen in Deutschland.
 Behalten Sie den Überblick über Arbeitszeiten, Überstunden und Urlaub.
     ]]></description>
 
-    <version>0.4.0</version>
+    <version>0.4.1</version>
     <licence>AGPL-3.0-or-later</licence>
 
     <author mail="axel.deffner@cpcmomentum.com" homepage="https://github.com/cpcMomentum">Axel Deffner</author>


### PR DESCRIPTION
Sync release v0.4.1 changes back to develop.