### PR TITLE
Release v0.4.3: Restore vendor/ (TCPDF) in tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-04-12
+
+### Fixed
+- TCPDF (vendor/) wieder im Tarball enthalten — war in v0.4.1 und v0.4.2 versehentlich ausgeschlossen, was zu Integritaetsfehlern und nicht funktionierendem PDF-Export fuehrte (#50)
+
 ## [0.4.2] - 2026-04-11
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Gesetzeskonforme Arbeitszeiterfassung für kleine Unternehmen in Deutschland.
 Behalten Sie den Überblick über Arbeitszeiten, Überstunden und Urlaub.
     ]]></description>
 
-    <version>0.4.2</version>
+    <version>0.4.3</version>
     <licence>AGPL-3.0-or-later</licence>
 
     <author mail="axel.deffner@cpcmomentum.com" homepage="https://github.com/cpcMomentum">Axel Deffner</author>


### PR DESCRIPTION
## Summary
- Hotfix release v0.4.3
- v0.4.1 and v0.4.2 accidentally excluded `vendor/` from the tarball — PDF export was broken and integrity checks failed
- This restores `vendor/` (TCPDF) in the tarball, signature and tarball are now consistent

## Testing
- Installation test with `occ integrity:check-app worktime`: passed
- Signature-Tarball consistency check: all 154 signed files present

🤖 Generated with [Claude Code](https://claude.com/claude-code)