### PR TITLE
feat: full legend for privileged users in absence overview

### DIFF
--- a/src/components/AbsenceTimeline.vue
+++ b/src/components/AbsenceTimeline.vue
@@ -69,6 +69,10 @@ export default {
 			type: Array,
 			default: () => [],
 		},
+		showFullLegend: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	computed: {
 		activeLegendItems() {
@@ -81,6 +85,12 @@ export default {
 				special: t('worktime', 'Sonderurlaub'),
 				compensatory: t('worktime', 'Freizeitausgleich'),
 				unpaid: t('worktime', 'Unbezahlt'),
+			}
+			// Privilegierte User (Admin/HR/Supervisor) sehen immer die volle Legende
+			// ohne "Abwesend" (das ist nur die maskierte Anzeige für Kollegen)
+			if (this.showFullLegend) {
+				const types = ['vacation', 'sick', 'child_sick', 'training', 'special', 'compensatory', 'unpaid']
+				return types.map(type => ({ type, label: typeLabels[type] }))
 			}
 			const usedTypes = new Set()
 			this.employees.forEach(emp => {

--- a/src/views/AbsenceOverviewView.vue
+++ b/src/views/AbsenceOverviewView.vue
@@ -15,12 +15,14 @@
             :employees="overview"
             :year="year"
             :month="month"
-            :holidays="holidays" />
+            :holidays="holidays"
+            :show-full-legend="isPrivileged" />
     </div>
 </template>
 
 <script>
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+import { mapGetters } from 'vuex'
 import MonthPicker from '../components/MonthPicker.vue'
 import AbsenceTimeline from '../components/AbsenceTimeline.vue'
 import AbsenceService from '../services/AbsenceService.js'
@@ -32,6 +34,12 @@ export default {
         NcLoadingIcon,
         MonthPicker,
         AbsenceTimeline,
+    },
+    computed: {
+        ...mapGetters('permissions', ['isAdmin', 'isHrManager', 'canApprove']),
+        isPrivileged() {
+            return this.isAdmin || this.isHrManager || this.canApprove
+        },
     },
     data() {
         const now = new Date()


### PR DESCRIPTION
Admin/HR/Supervisor see all absence types in legend, not only those present in data.