### PR TITLE
fix(worktime): OC_App::getAppPath → IAppManager (NC 33 compat) (#88)

### DIFF
--- a/lib/Migration/CleanupExtraFiles.php
+++ b/lib/Migration/CleanupExtraFiles.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OCA\WorkTime\Migration;
 
+use OCP\App\AppPathNotFoundException;
+use OCP\App\IAppManager;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
@@ -13,13 +15,19 @@ use OCP\Migration\IRepairStep;
  */
 class CleanupExtraFiles implements IRepairStep {
 
+	public function __construct(
+		private IAppManager $appManager,
+	) {
+	}
+
 	public function getName(): string {
 		return 'Remove extra files from earlier releases';
 	}
 
 	public function run(IOutput $output): void {
-		$appPath = \OC_App::getAppPath('worktime');
-		if ($appPath === false) {
+		try {
+			$appPath = $this->appManager->getAppPath('worktime');
+		} catch (AppPathNotFoundException) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- CleanupExtraFiles RepairStep nutzte \OC_App::getAppPath() (seit NC 11 deprecated, in NC 33 entfernt)
- Crash: Call to undefined method OC_App::getAppPath() bei occ upgrade/app:enable auf NC 33
- Fix: IAppManager per Constructor injizieren, AppPathNotFoundException behandeln
- Lokal auf NC 33.0.2 verifiziert: alter Code crasht reproduzierbar, neuer Code laeuft sauber durch

## Test plan
- [x] NC 32 → NC 33.0.2 Upgrade mit altem Code reproduziert Crash (Error: Call to undefined method OC_App::getAppPath())
- [x] Mit Fix: occ maintenance:repair laeuft sauber, "Remove extra files from earlier releases" wird ausgefuehrt
- [x] RepairStep aendert nichts am Verhalten bei fehlendem AppPath (silent return)

Fixes #88