### PR TITLE
chore: adopt ai-first-dev plugin v4.0.1

### DIFF
--- a/.claude/dev.md
+++ b/.claude/dev.md
@@ -1,0 +1,203 @@
+# AI Development Guidelines
+
+## 1. Technology Stack
+
+**Siehe `techstack.md` für den vollständigen, standardmäßig zu verwendenden TechStack.**
+
+Wichtigste Prinzipien:
+- Containerisierung (Docker) ist EMPFOHLEN, aber nicht fuer alle Projekte zwingend (siehe techstack.md Sektion "Infrastruktur")
+- Dependency Versions muessen immer gepinned sein (NO `:latest` tags)
+- State-of-the-art Libraries fuer Auth verwenden (NO custom auth logic)
+
+## 2. Development Guidelines
+
+### AI Agent Behavior
+- **Research First**: Never guess. Perform research for up-to-date knowledge before coding.
+- **Context7**: Use https://context7.com/ for current library documentation and versions.
+- **Subagents**: Utilize subagents for specialized tasks.
+- **Context**: Always read `dev.md` first as the source of truth.
+- **Plugins nutzen**: Alle 6 Pflicht-Plugins aktiv einsetzen (siehe unten).
+
+### Plugins (Anthropic Marketplace)
+
+Diese Plugins werden bei `/ai-first-dev:setup` installiert. Welche Plugins benoetigt werden, haengt vom **Tech-Stack** ab (siehe `techstack.md` Sektion "Plugins").
+
+**Core-Plugins (immer):**
+
+| Plugin | Kategorie | Wirkung |
+|--------|-----------|---------|
+| `context7` | Recherche | Aktuelle Library-Dokumentation |
+| `security-guidance` | Sicherheit | Automatische Warnungen bei Security-Problemen |
+
+**Stack-spezifische Plugins (bedingt):**
+
+| Plugin | Kategorie | Wann benoetigt |
+|--------|-----------|----------------|
+| `typescript-lsp` | Code Intelligence | TypeScript im Stack |
+| `pyright-lsp` | Code Intelligence | Python im Stack |
+| `playwright` | Testing | Frontend vorhanden |
+| `frontend-design` | Frontend | Frontend vorhanden |
+
+**Pruefung:** `/setup-plugins` prueft ob die fuer den Stack relevanten Plugins installiert sind.
+
+### Recherche-Ressourcen
+
+| Ressource | Plugin/Tool | Verwendung |
+|-----------|-------------|------------|
+| **Context7** | `context7` Plugin | Aktuelle Library-Dokumentation, Versionen, Best Practices |
+| WebSearch | Built-in | Fallback, allgemeine Recherche |
+| .claude/techstack.md | lokal | Standard Tech-Stack Definition |
+| .claude/standards/ | lokal | Projekt-spezifische Standards |
+
+### Version Control (Git)
+
+#### GRUNDREGEL: Niemals direkt auf `main` oder `develop` arbeiten!
+
+Alle Änderungen entstehen auf Feature-Branches und gelangen **ausschließlich via Pull Request** in protected Branches.
+
+#### Branches
+
+| Branch | Zweck | Schutz |
+|--------|-------|--------|
+| `main` | Produktion, immer stabil | Protected: PR + 1 Review + CI |
+| `develop` | Integration für Features | Protected: PR + CI |
+| `feature/*` | Neue Funktionalität | Frei |
+| `bugfix/*` | Fehlerbehebung | Frei |
+| `hotfix/*` | Kritische Fixes (direkt → main) | Frei |
+| `release/*` | Release-Branches (`release/vX.Y.Z`) | Frei |
+| `chore/*` | Maintenance, Dependencies | Frei |
+| `docs/*` | Dokumentation | Frei |
+| `refactor/*` | Code-Refactoring | Frei |
+
+#### Branch-Naming
+
+```
+<type>/<beschreibung>
+<type>/<issue-id>-<beschreibung>
+```
+
+**Regeln:**
+- Alles lowercase, Wörter mit `-` getrennt
+- Issue-ID optional (empfohlen wenn Issue existiert)
+- Kurz und beschreibend
+
+**Beispiele:**
+- `feature/new-ui-design`
+- `feature/42-user-authentication`
+- `bugfix/87-login-token-expiry`
+- `hotfix/critical-security-patch`
+- `release/v1.2.0`
+- `chore/update-dependencies`
+- `refactor/optimize-db-queries`
+
+**Validierung:** GitHub Action prüft automatisch: `^(feature|bugfix|hotfix|release|chore|docs|refactor)\/[a-z0-9.-]+$`
+
+#### Merge-Flow
+
+```
+feature/*  ──PR──▶ develop ──PR+Review──▶ main
+bugfix/*   ──PR──▶ develop ──PR+Review──▶ main
+release/*  ──PR+Review──────────────────────▶ main
+hotfix/*   ──PR+Review──────────────────────▶ main
+```
+
+#### Commit-Messages (Conventional Commits)
+
+```
+<type>(<scope>): <beschreibung>
+
+[optionaler body]
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+| Type | Beschreibung | Beispiel |
+|------|-------------|---------|
+| `feat` | Neues Feature | `feat(auth): add OAuth2 login` |
+| `fix` | Bugfix | `fix(api): correct pagination offset` |
+| `docs` | Dokumentation | `docs: update API reference` |
+| `refactor` | Refactoring | `refactor(db): optimize query structure` |
+| `chore` | Maintenance | `chore: update dependencies` |
+| `test` | Tests | `test: add auth unit tests` |
+| `perf` | Performance | `perf(queries): add database indexes` |
+| `ci` | CI/CD | `ci: add security scan step` |
+| `style` | Formatting | `style: fix linting errors` |
+
+#### PR-Titel (PFLICHT: Conventional Commits Format)
+
+```
+<type>(<scope>): <beschreibung>
+```
+
+**Regeln:**
+- Selbes Format wie Commit-Messages
+- Max. 72 Zeichen
+- Beschreibung im Imperativ ("add", nicht "added")
+- Scope optional aber empfohlen
+
+**Beispiele:**
+- `feat(auth): add user registration with email verification`
+- `fix(api): resolve pagination bug on contracts endpoint`
+- `refactor(database): migrate from raw SQL to SQLAlchemy ORM`
+- `chore: update Next.js to v15.1`
+
+**Validierung:** GitHub Action prüft automatisch: `^(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(\(.+\))?: .{1,72}$`
+
+**Nicht erlaubt:**
+- `Added some stuff` (kein Typ-Prefix)
+- `feat: this is a very long title that exceeds the character limit and is hard to read` (zu lang)
+- `Feature/user auth` (Branch-Name statt PR-Titel)
+
+#### CHANGELOG
+
+- `CHANGELOG.md` dokumentiert alle Änderungen (Keep a Changelog Format)
+- Muss **vor jedem PR nach `main`** aktualisiert werden
+- Wird automatisch aus Conventional Commits generiert (`/changelog`)
+
+#### Versionierung
+
+- **Semantic Versioning** (X.Y.Z): Major.Minor.Patch
+- Versionsnummer immer inkrementieren
+- Version im Docker Container-Namen verwenden
+
+#### Stages
+
+- **DEV-Stage**: Entwickler kann außerhalb der lokalen Maschine testen
+- **PROD-Stage**: Nur nach bestandener QA
+
+> **Vollständige Dokumentation:** `.claude/standards/github-branch-protection.md`
+
+### Security
+- **Secrets**:
+    - NEVER commit credentials/secrets (`.env`).
+    - Keep secrets server-side only.
+    - Maintain strict `.gitignore`.
+- **Auth**: Use state-of-the-art middleware/libraries. No custom auth logic.
+- **CORS**: Configure strictly (allowlist only) for Frontend/Backend communication.
+- **HTTPS**: Ensure all connections are secure.
+- **Security**: Follow OWASP Top 10.
+- **Rate Limiting**: Implement rate limiting.
+- **Logging**: Implement structured logging.
+- **Monitoring**: Implement monitoring.
+- **Backup**: Implement backup. 
+
+### Testing & Quality
+- **MVP Strategy**: Unit tests ONLY.
+    - Use unit tests to validate success.
+    - **User Confirmation**: User must approve the choice of unit tests.
+- **Code Quality**:
+    - Dependency auditing & linting required (siehe `techstack.md` für Tools).
+    - **Dependencies**: Pin versions. NO `:latest` tags in `package.json`.
+    - **Logs**: Minimal, no PII data.
+
+### Mandatory Project Structure & Documentation
+- **Source of Truth**:
+    - `dev.md` (This file): HOW to develop
+    - `techstack.md`: WHAT technologies to use
+- **Required Files**:
+    - `project.md`: Natural language description & guardrails.
+    - `plan.md`: Top-level roadmap & critical decisions.
+    - `phase X.md`: Detailed specs & mandatory tests for current phase.
+    - `claude.md`: Minimal, project-specific instructions (deployment, how-to) derived from `dev.md` and `techstack.md`.
+    - `README.md`: What, How, Setup, API docs.
+    - `LICENSE.md`: Included in setup.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "enabledPlugins": {
+    "ai-first-dev@cpcmomentum": true,
+    "context7@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true
+  }
+}

--- a/.claude/techstack.md
+++ b/.claude/techstack.md
@@ -1,0 +1,310 @@
+# TechStack Preset: Nextcloud App
+
+> **Preset-ID:** nextcloud-app
+> **Beschreibung:** Nextcloud App Entwicklung — PHP Backend (OCP APIs) + Vue.js Frontend (@nextcloud/vue).
+> **Erkennungssignal:** `appinfo/info.xml` im Projekt-Root.
+
+---
+
+## 1. Core Stack
+
+### Backend
+| Technologie | Version | Zweck |
+|-------------|---------|-------|
+| PHP | 8.1+ (Type Hints Pflicht) | Sprache |
+| Nextcloud OCP APIs | NC 30+ | Framework (KEINE frei waehlbaren Frameworks) |
+| Nextcloud IContainer | - | Dependency Injection |
+
+### Frontend
+| Technologie | Version | Zweck |
+|-------------|---------|-------|
+| Vue.js | 2 (LTS) oder 3 | Frontend Framework |
+| @nextcloud/vue | latest | NC-native UI-Komponenten (NcAppContent, NcButton, etc.) |
+| Vuex 3 / Pinia | - | State Management (Vuex fuer Vue 2, Pinia fuer Vue 3) |
+| vue-router | 3 (Vue 2) / 4 (Vue 3) | Routing — **Hash-Mode Pflicht, NICHT History-Mode** |
+| @nextcloud/axios | latest | HTTP Client |
+| @nextcloud/router | latest | URL-Generierung (generateUrl()) |
+| @nextcloud/l10n | latest | Uebersetzungen |
+
+### Database
+| Technologie | Zweck |
+|-------------|-------|
+| MySQL / MariaDB / PostgreSQL / SQLite | Vom Host vorgegeben — NICHT frei waehlbar |
+| OCP\IDBConnection Query Builder | Datenbankzugriff — **raw SQL ist VERBOTEN** |
+| OCP\Migration\IMigrationStep | Schema-Migrationen in lib/Migration/ |
+
+## 2. Tooling
+
+### PHP
+| Tool | Zweck |
+|------|-------|
+| `php -l` | Syntax-Check (typisch im Docker-Container) |
+| PHPUnit + Nextcloud TestCase | Unit Tests |
+| psalm / phpstan | Statische Analyse (optional, app-spezifisch) |
+
+### JavaScript
+| Tool | Zweck |
+|------|-------|
+| webpack (@nextcloud/webpack-vue-config) | Build |
+| eslint (@nextcloud/eslint-config) | Linting |
+| jest | Tests (optional) |
+
+## 3. Infrastructure
+
+| Aspekt | Details |
+|--------|---------|
+| Container | **NEIN** — App laeuft IN Nextcloud, nicht daneben |
+| Lokale Entwicklung | Nextcloud im Docker (OrbStack), Mount nach `/var/www/html/custom_apps/worktime` |
+| Deploy: App Store | Tarball + Signatur + REST API Upload |
+| Deploy: Inhouse | rsync auf eigene Instanz + `occ upgrade` |
+| CI/CD | App Store Release-Pipeline (NICHT GitHub Actions fuer Deploy) |
+| Hosting | Nextcloud-Server (self-hosted oder Managed) |
+
+## 4. Auth & Security
+
+| Aspekt | Loesung |
+|--------|---------|
+| Auth | Vom Host — `OCP\IUserSession` injizieren, `getUser()` nutzen |
+| CSRF | NC-Framework erzwingt `requesttoken` Header bei allen Writes |
+| XSS | Vue-Rendering safe by default; in PHP: `p()` / `print_unescaped()` |
+| SQLi | Nur Query Builder — raw SQL **verboten** |
+| Lizenz | **AGPL-3.0-or-later** (App Store Pflicht) |
+
+## 5. Versionierung
+
+- SemVer in `appinfo/info.xml` → `<version>X.Y.Z</version>`
+- Synchron in `package.json` → `"version": "X.Y.Z"`
+- NC-Kompatibilitaet: `<dependencies><nextcloud min-version="30" max-version="33"/></dependencies>`
+
+## Projektstruktur
+
+```
+<app-name>/
+├── appinfo/
+│   ├── info.xml            # PFLICHT — App-Metadaten
+│   ├── routes.php          # URL-Routing (Controller-Mapping)
+│   └── signature.json      # Release-Prozess generiert (Integrity-Check)
+├── lib/
+│   ├── AppInfo/
+│   │   └── Application.php # Bootstrapping, DI-Registration
+│   ├── Controller/         # extends OCP\AppFramework\Controller
+│   ├── Service/            # Business Logic
+│   ├── Db/                 # Entities + Mapper (extends QBMapper)
+│   ├── Migration/          # Schema-Migrationen + Repair Steps
+│   ├── Notification/       # Notifier (optional)
+│   ├── Listener/           # Event Listener
+│   └── Settings/           # Admin/Personal Settings
+├── src/                    # Vue Frontend Source
+│   ├── main.js             # Entry
+│   ├── App.vue
+│   ├── components/
+│   ├── views/
+│   ├── store/              # Vuex / Pinia
+│   └── router.js
+├── js/                     # KOMPILIERTES JS (commit Pflicht!)
+│   ├── worktime-main.js
+│   └── worktime-main.js.map
+├── css/                    # Optional
+├── templates/              # PHP-Templates (main.php als Vue-Mount-Point)
+├── l10n/                   # Uebersetzungen (Transifex)
+├── tests/                  # PHPUnit
+├── docs/
+│   └── produktbeschreibung.md
+├── CHANGELOG.md
+├── CLAUDE.md
+├── composer.json
+├── package.json
+├── webpack.config.js       # require('@nextcloud/webpack-vue-config')
+└── README.md
+```
+
+## Command Mappings
+
+| Concept | Command |
+|---------|---------|
+| `lint_frontend` | `npm run lint` |
+| `lint_backend` | `docker exec -t nextcloud-dev php -l /var/www/html/custom_apps/worktime/lib/**/*.php` |
+| `format_frontend` | `npx prettier --write src/` |
+| `format_backend` | `N/A` |
+| `typecheck` | `N/A` |
+| `test_frontend` | `npm run test` |
+| `test_backend` | `docker exec -t nextcloud-dev php /var/www/html/custom_apps/worktime/vendor/bin/phpunit -c /var/www/html/custom_apps/worktime/tests/phpunit.xml` |
+| `build_frontend` | `npm run build` |
+| `build_backend` | `N/A` |
+| `dep_audit_fe` | `npm audit` |
+| `dep_audit_be` | `N/A` |
+| `install_deps_fe` | `npm install` |
+| `install_deps_be` | `composer install` |
+
+> **Hinweis:** `worktime` wird bei `/adopt` durch den tatsaechlichen App-Namen (aus `appinfo/info.xml`) ersetzt. PHP-Lint laeuft im Docker-Container weil PHP auf macOS typisch nicht installiert ist.
+
+## Plugins
+
+| Kategorie | Plugin | Benoetigt? |
+|-----------|--------|------------|
+| Recherche | `context7` | Ja |
+| Security | `security-guidance` | Ja |
+| Testing | `playwright` | Optional (NC-Apps nutzen eher manuelles Testing) |
+| Type-Check Frontend | `typescript-lsp` | Wenn TypeScript im Vue-Setup |
+| UI Design | `frontend-design` | Optional |
+
+## Pflicht-Konventionen
+
+> **Nicht optional** — App Store Ablehnung oder NC-Major-Update-Breakage bei Verstoss.
+
+| Regel | Grund |
+|-------|-------|
+| Nur `OCP\*` APIs, niemals `OC\*` | `OC\*` ist privat, instabil — Breakage bei jedem Major-Update |
+| Kein raw SQL, nur Query Builder | SQL-Injection + DB-Portabilitaet (MySQL/Postgres/SQLite) |
+| AGPL-3.0-or-later ueberall | Harte App-Store-Pflicht |
+| Kein "Nextcloud" im App-Namen | Marken-Policy |
+| Type Hints in PHP | Projektstandard |
+| Assets-Pfad: `js/worktime-main.js` | NC laedt JS aus `js/`, nicht aus `dist/` |
+| `npm run build` vor Commit bei Vue-Aenderungen | Ohne kompiliertes JS laeuft die App nicht |
+| Keine `.htaccess`/`.user.ini` im Release | NC FilenameValidator strippt diese → Signatur bricht |
+| Hash-Routing im Vue Router | NC-Apps laufen unter `/apps/worktime/` ohne History-API |
+
+## Nicht-anwendbare ai-first-dev Skills
+
+Diese Skills sind fuer NC-Apps **nicht relevant** und sollten uebersprungen werden:
+
+| Skill | Grund |
+|-------|-------|
+| `setup-ci`, `setup-deploy` | CI/CD ist App Store Release, nicht GitHub Actions Deploy |
+| `setup-logging` | Logging ueber NC-eigenes `OCP\ILogger` |
+| `api-sync` | NC-Apps haben keine OpenAPI-Spec |
+| `generate-legal-docs` | Lizenz ist fix AGPL |
+| `qa` (Playwright) | Optional — manuelles Testing ueblicher bei NC-Apps |
+
+---
+
+## Skill-Konventionen
+
+> **Diese Regeln werden von den bestehenden ai-first-dev Skills automatisch gelesen und angewendet.** Keine separaten Skills noetig — die Methodik bleibt gleich, nur die stack-spezifischen Regeln aendern sich.
+
+### /release
+
+| Regel | Details |
+|-------|---------|
+| Branch-Pflicht | Release nur von `develop`, nicht von `main` oder Feature-Branches |
+| Release-Branch | `release/vX.Y.Z` von `develop` abzweigen |
+| Version synchron | `appinfo/info.xml` UND `package.json` muessen gleiche Version haben |
+| Build vor Tarball | `npm install && npm run build` auf dem Release-Branch |
+| Tarball aus git archive | `git archive HEAD` verwenden, **NICHT** aus Worktree — verhindert Feature-Code-Leaks |
+| Sign-Tree bereinigen | `.htaccess`, `.user.ini` aus Sign-Tree entfernen (NC FilenameValidator) |
+| Signatur | `openssl dgst -sha512 -sign ~/.nextcloud/certificates/worktime.key` |
+| Upgrade-Test PFLICHT | Vorversion installieren → neue Version drueberziehen → Integrity pruefen |
+| Whitelist-Check | Tarball darf NUR enthalten: `appinfo`, `lib`, `src`, `js`, `css`, `templates`, `l10n`, `img`, `tests`, `composer.json`, `package.json`, `package-lock.json`, `webpack.config.js`, `CHANGELOG.md`, `README.md`, `LICENSE`, `CLAUDE.md` |
+| App Store Upload | `curl -X POST https://apps.nextcloud.com/api/v1/apps/releases` mit Signatur |
+| Post-Release Sync | Release-Branch → `main` mergen, dann `main` → `develop` zuruecksyncen |
+| Rollback | Defekte Version im App Store loeschen: `curl -X DELETE .../releases/<version>` |
+
+### /prime
+
+| Regel | Details |
+|-------|---------|
+| Pattern-Check PFLICHT | Vor Implementation IMMER bestehende Views/Komponenten durchsuchen — NC-Apps sind stark konventionsgetrieben. Patterns (z.B. NcAppNavigation-Nutzung) muessen wiederverwendet werden. |
+| OCP-API Referenz | Pruefen welche OCP-APIs in der App bereits genutzt werden, um neue Features konsistent zu implementieren |
+| API im Container verifizieren | `docker exec -t nextcloud-dev cat /var/www/html/lib/public/<Interface>.php` — nie aus dem Gedaechtnis coden |
+| @nextcloud/* pruefen | Frontend-Pakete (@nextcloud/vue, @nextcloud/dialogs) vor Nutzung im `node_modules/` verifizieren |
+
+### /design
+
+| Regel | Details |
+|-------|---------|
+| Pattern-Check VOR Alternativen | Bestehende Views analysieren BEVOR Alternativen erwogen werden |
+| NC-API-Recherche PFLICHT | Design darf nicht auf "irgendeine API" bauen — nur auf real existierende OCP-Interfaces |
+| Hash-Routing beachten | Alle Navigations-Designs muessen Hash-Routing beruecksichtigen |
+| @nextcloud/vue nutzen | UI-Komponenten aus @nextcloud/vue bevorzugen (NcButton, NcAppContent, NcModal, etc.) |
+
+### /plan (create-plan)
+
+| Regel | Details |
+|-------|---------|
+| OCP-Interface-Verifikation | **Blocker-Schritt** — Plan kann nicht finalisiert werden bevor alle referenzierten APIs im Docker-Container verifiziert wurden |
+| Pattern-Check vorgezogen | Bestehende Patterns analysieren bevor neue Architektur geplant wird |
+| Keine verbotenen APIs | Plan darf keine `OC\*` APIs, raw SQL oder History-Routing enthalten |
+| Version Impact | Bei Schema-Aenderungen: Migration planen, bei API-Aenderungen: NC-Kompatibilitaetsbereich pruefen |
+
+### /bugfix
+
+| Regel | Details |
+|-------|---------|
+| Pattern-Check | Vor Fix bestehende Patterns analysieren — oft liegt der Bug in Abweichung vom Pattern |
+| Deploy nach Build | Nach jedem Build automatisch in Docker-Container deployen: `docker exec -u www-data nextcloud-dev php occ maintenance:repair` |
+| NC-API pruefen | Bei API-bezogenen Bugs: Interface-Signatur im Container verifizieren (APIs aendern sich zwischen NC-Majors) |
+| Bool-Handling | Bei DB-Bugs: Bool als SmallInt pruefen (MySQL-Kompatibilitaet) |
+
+### /validate
+
+| Regel | Details |
+|-------|---------|
+| Build Output pruefen | `npm run build` muss `js/worktime-main.js` erzeugen |
+| PHP-Lint im Container | `docker exec -t nextcloud-dev php -l ...` weil PHP auf macOS nicht installiert |
+| info.xml validieren | Pflicht-Felder pruefen: id, name, summary, description, version, licence, author, namespace, category, dependencies |
+| Version-Sync | info.xml Version == package.json Version |
+
+### /scaffold
+
+| Regel | Details |
+|-------|---------|
+| Controller | `extends OCP\AppFramework\Controller`, `#[NoAdminRequired]` Attribute, DI ueber Constructor |
+| Service + Mapper Paar | Immer zusammen generieren — Controller → Service → Mapper Schichtung |
+| Entity | `extends OCP\AppFramework\Db\Entity`, Getter/Setter automatisch, `addType()` im Constructor |
+| Migration | `extends SimpleMigrationStep`, Naming: `VersionXXXYYYDateYYYYMMDDHHMMSS`, nur Schema Builder |
+| Tabellennamen | Prefix mit App-ID: `worktime_<tablename>` |
+| Route hinzufuegen | Neuen Controller in `appinfo/routes.php` registrieren |
+| Vue Component | @nextcloud/vue Komponenten nutzen (NcAppContent, NcButton, etc.), Hash-Routing |
+
+### /changelog
+
+| Regel | Details |
+|-------|---------|
+| Version aus info.xml | Version aus `appinfo/info.xml` lesen, nicht aus package.json |
+
+---
+
+## Agent-Kontext
+
+> **Diese Informationen werden von allen Agenten (code-reviewer, debugger, research-analyst, etc.) gelesen wenn sie an diesem Projekt arbeiten.** Keine separaten NC-Agenten noetig.
+
+### Kern-Wissen fuer alle Agenten
+
+- **Runtime:** Die App laeuft INNERHALB von Nextcloud (PHP), nicht als eigenstaendiger Service
+- **Kein Docker fuer die App:** Docker wird nur als Entwicklungsumgebung genutzt (Nextcloud-Instanz im Container)
+- **API-Einschraenkung:** Nur `OCP\*` APIs erlaubt, niemals `OC\*` (privat, instabil)
+- **DB-Zugriff:** Nur ueber OCP Query Builder, kein raw SQL, kein eigenes ORM
+- **Frontend:** Vue 2/3 mit @nextcloud/vue Komponenten, Hash-Routing, webpack
+- **Auth:** Bereitgestellt vom Host — `OCP\IUserSession`, kein eigenes Auth-System
+- **Lizenz:** AGPL-3.0-or-later ist Pflicht (App Store)
+- **Build-Output committen:** `js/` Verzeichnis mit kompiliertem JS muss committed werden
+
+### Fuer code-reviewer
+
+- Pruefe ob nur `OCP\*` APIs genutzt werden (keine `OC\*`)
+- Pruefe ob DB-Zugriff nur ueber Query Builder laeuft
+- Pruefe ob Type Hints in PHP vorhanden sind
+- Pruefe ob neue Routes in `appinfo/routes.php` registriert sind
+- Pruefe ob `#[NoAdminRequired]` korrekt gesetzt ist
+- Pruefe ob AGPL-Header in neuen Dateien vorhanden ist
+
+### Fuer debugger
+
+- PHP-Fehler im Docker-Container pruefen: `docker exec -t nextcloud-dev tail -f /var/www/html/data/nextcloud.log`
+- OCP-API Signaturen im Container verifizieren bevor Fixes vorgeschlagen werden
+- Bool-Handling (MySQL SmallInt vs. Boolean) bei DB-Problemen pruefen
+- Bei Integrity-Fehlern: `FILE_MISSING` = Datei im Tarball aber nicht auf Disk, `EXTRA_FILE` = Datei auf Disk aber nicht im Tarball
+
+### Fuer security-auditor
+
+- CSRF wird vom NC-Framework erzwungen (`requesttoken` Header)
+- XSS: Vue safe by default, in PHP `p()` / `print_unescaped()` pruefen
+- SQL Injection: Nur Query Builder, raw SQL ist verboten
+- Keine Secrets in `info.xml` oder committed JS
+
+### Fuer research-analyst
+
+- NC-Dokumentation: https://docs.nextcloud.com/server/latest/developer_manual/
+- OCP-APIs verifizieren via: `docker exec -t nextcloud-dev cat /var/www/html/lib/public/<Interface>.php`
+- @nextcloud/* Pakete: `node_modules/@nextcloud/<pkg>/` einsehen
+- Context7 fuer aktuelle @nextcloud/vue Dokumentation nutzen


### PR DESCRIPTION
Generates .claude/ via the plugin's adopt skill. Moves NC-specific conventions into .claude/techstack.md so /ai-first-dev:release etc. read them. Our .githooks/pre-commit remains.