### PR TITLE
fix(l10n): translate notifications and validation messages

### DIFF
--- a/l10n/en.json
+++ b/l10n/en.json
@@ -373,7 +373,32 @@
         "Thüringen": "Thuringia",
 
         "HR-Manager können Mitarbeiter verwalten und Anträge genehmigen.": "HR managers can manage employees and approve requests.",
-        "{count} Einträge wurden genehmigt.": "{count} entries have been approved."
+        "{count} Einträge wurden genehmigt.": "{count} entries have been approved.",
+
+        "%1$s hat eine Abwesenheit (%2$s, %3$s - %4$s) zur Genehmigung eingereicht": "%1$s submitted an absence (%2$s, %3$s - %4$s) for approval",
+        "Deine Abwesenheit (%1$s, %2$s - %3$s) wurde genehmigt": "Your absence (%1$s, %2$s - %3$s) has been approved",
+        "Deine Abwesenheit (%1$s, %2$s - %3$s) wurde abgelehnt": "Your absence (%1$s, %2$s - %3$s) has been rejected",
+        "Information: %1$s ist abwesend (%2$s, %3$s - %4$s)": "Information: %1$s is absent (%2$s, %3$s - %4$s)",
+        "%1$s hat Abwesenheit (%2$s, %3$s - %4$s) storniert": "%1$s cancelled absence (%2$s, %3$s - %4$s)",
+        "%1$s hat Zeiteinträge für %2$s zur Genehmigung eingereicht": "%1$s submitted time entries for %2$s for approval",
+        "Deine Zeiteinträge für %s wurden genehmigt": "Your time entries for %s have been approved",
+        "Deine Zeiteinträge für %s wurden abgelehnt": "Your time entries for %s have been rejected",
+
+        "Zukünftige Einträge sind nicht erlaubt": "Future entries are not allowed",
+        "Ungültiges Zeitformat": "Invalid time format",
+        "Maximale tägliche Arbeitszeit (%s Std.) überschritten": "Maximum daily working time (%s hours) exceeded",
+        "Mindestpause von %d Minuten erforderlich": "Minimum break of %d minutes required",
+        "Pause kann nicht negativ sein": "Break cannot be negative",
+        "An diesem Tag haben Sie %s. Bitte stornieren Sie zuerst die Abwesenheit.": "You have %s on this day. Please cancel the absence first.",
+        "Überlappung mit bestehendem Eintrag (%1$s - %2$s)": "Overlap with existing entry (%1$s - %2$s)",
+
+        "Scope muss zwischen 0 und 1 liegen": "Scope must be between 0 and 1",
+        "Halber Tag ist nur für einen einzelnen Tag möglich": "Half day is only possible for a single day",
+        "Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)": "Day %1$s cannot be removed (month %2$02d/%3$d is approved)",
+
+        "Gültig-ab darf frühestens der 1. des aktuellen Monats sein": "Valid-from must be no earlier than the 1st of the current month",
+        "Ein Profil mit diesem Gültig-ab Datum existiert bereits": "A profile with this valid-from date already exists",
+        "Maximale tägliche Arbeitszeit ist %s Stunden (siehe Einstellungen)": "Maximum daily working time is %s hours (see settings)"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -6,6 +6,7 @@ namespace OCA\WorkTime\Notification;
 
 use OCA\WorkTime\AppInfo\Application;
 use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 use OCP\Notification\UnknownNotificationException;
@@ -14,6 +15,7 @@ class Notifier implements INotifier {
 
 	public function __construct(
 		private IURLGenerator $urlGenerator,
+		private IFactory $l10nFactory,
 	) {
 	}
 
@@ -30,91 +32,104 @@ class Notifier implements INotifier {
 			throw new UnknownNotificationException();
 		}
 
+		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
 		$params = $notification->getSubjectParameters();
 
 		switch ($notification->getSubject()) {
 			case 'absence_submitted':
 				$notification->setParsedSubject(
-					sprintf(
-						'%s hat eine Abwesenheit (%s, %s - %s) zur Genehmigung eingereicht',
-						$params['employeeName'],
-						$params['typeName'],
-						$params['startDate'],
-						$params['endDate']
+					$l->t(
+						'%1$s hat eine Abwesenheit (%2$s, %3$s - %4$s) zur Genehmigung eingereicht',
+						[
+							$params['employeeName'],
+							$params['typeName'],
+							$params['startDate'],
+							$params['endDate'],
+						]
 					)
 				);
 				break;
 
 			case 'absence_approved':
 				$notification->setParsedSubject(
-					sprintf(
-						'Deine Abwesenheit (%s, %s - %s) wurde genehmigt',
-						$params['typeName'],
-						$params['startDate'],
-						$params['endDate']
+					$l->t(
+						'Deine Abwesenheit (%1$s, %2$s - %3$s) wurde genehmigt',
+						[
+							$params['typeName'],
+							$params['startDate'],
+							$params['endDate'],
+						]
 					)
 				);
 				break;
 
 			case 'absence_rejected':
 				$notification->setParsedSubject(
-					sprintf(
-						'Deine Abwesenheit (%s, %s - %s) wurde abgelehnt',
-						$params['typeName'],
-						$params['startDate'],
-						$params['endDate']
+					$l->t(
+						'Deine Abwesenheit (%1$s, %2$s - %3$s) wurde abgelehnt',
+						[
+							$params['typeName'],
+							$params['startDate'],
+							$params['endDate'],
+						]
 					)
 				);
 				break;
 
 			case 'absence_informational':
 				$notification->setParsedSubject(
-					sprintf(
-						'Information: %s ist abwesend (%s, %s - %s)',
-						$params['employeeName'],
-						$params['typeName'],
-						$params['startDate'],
-						$params['endDate']
+					$l->t(
+						'Information: %1$s ist abwesend (%2$s, %3$s - %4$s)',
+						[
+							$params['employeeName'],
+							$params['typeName'],
+							$params['startDate'],
+							$params['endDate'],
+						]
 					)
 				);
 				break;
 
 			case 'absence_cancelled':
 				$notification->setParsedSubject(
-					sprintf(
-						'%s hat Abwesenheit (%s, %s - %s) storniert',
-						$params['employeeName'],
-						$params['typeName'],
-						$params['startDate'],
-						$params['endDate']
+					$l->t(
+						'%1$s hat Abwesenheit (%2$s, %3$s - %4$s) storniert',
+						[
+							$params['employeeName'],
+							$params['typeName'],
+							$params['startDate'],
+							$params['endDate'],
+						]
 					)
 				);
 				break;
 
 			case 'time_entries_submitted':
 				$notification->setParsedSubject(
-					sprintf(
-						'%s hat Zeiteinträge für %s zur Genehmigung eingereicht',
-						$params['employeeName'],
-						$params['monthYear']
+					$l->t(
+						'%1$s hat Zeiteinträge für %2$s zur Genehmigung eingereicht',
+						[
+							$params['employeeName'],
+							$params['monthYear'],
+						]
 					)
 				);
 				break;
 
 			case 'time_entries_approved':
 				$notification->setParsedSubject(
-					sprintf(
+					$l->t(
 						'Deine Zeiteinträge für %s wurden genehmigt',
-						$params['monthYear']
+						[$params['monthYear']]
 					)
 				);
 				break;
 
 			case 'time_entries_rejected':
 				$notification->setParsedSubject(
-					sprintf(
+					$l->t(
 						'Deine Zeiteinträge für %s wurden abgelehnt',
-						$params['monthYear']
+						[$params['monthYear']]
 					)
 				);
 				break;

--- a/lib/Service/AbsenceService.php
+++ b/lib/Service/AbsenceService.php
@@ -12,6 +12,7 @@ use OCA\WorkTime\Db\EmployeeMapper;
 use OCA\WorkTime\Db\HolidayMapper;
 use OCA\WorkTime\Notification\NotificationService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 
 class AbsenceService {
@@ -25,6 +26,7 @@ class AbsenceService {
         private NotificationService $notificationService,
         private WorkScheduleService $workScheduleService,
         private LoggerInterface $logger,
+        private IL10N $l,
     ) {
     }
 
@@ -402,12 +404,12 @@ class AbsenceService {
 
         // Scope must be between 0 and 1
         if ($scope < 0 || $scope > 1) {
-            $errors['scope'] = ['Scope muss zwischen 0 und 1 liegen'];
+            $errors['scope'] = [$this->l->t('Scope muss zwischen 0 und 1 liegen')];
         }
 
         // Half day (scope < 1) must be single day
         if ($scope < 1.0 && $startDate->format('Y-m-d') !== $endDate->format('Y-m-d')) {
-            $errors['scope'] = ['Halber Tag ist nur für einen einzelnen Tag möglich'];
+            $errors['scope'] = [$this->l->t('Halber Tag ist nur für einen einzelnen Tag möglich')];
         }
 
         // Check for overlapping absences
@@ -445,11 +447,13 @@ class AbsenceService {
                     $year = (int)$day->format('Y');
                     $month = (int)$day->format('n');
                     if ($this->timeEntryService->isMonthApproved($absence->getEmployeeId(), $year, $month)) {
-                        $errors[] = sprintf(
-                            'Tag %s kann nicht entfernt werden (Monat %02d/%d ist genehmigt)',
-                            $day->format('d.m.Y'),
-                            $month,
-                            $year
+                        $errors[] = $this->l->t(
+                            'Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)',
+                            [
+                                $day->format('d.m.Y'),
+                                $month,
+                                $year,
+                            ]
                         );
                     }
                 }

--- a/lib/Service/TimeEntryService.php
+++ b/lib/Service/TimeEntryService.php
@@ -14,6 +14,7 @@ use OCA\WorkTime\Db\TimeEntry;
 use OCA\WorkTime\Db\TimeEntryMapper;
 use OCA\WorkTime\Notification\NotificationService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 
 class TimeEntryService {
@@ -26,6 +27,7 @@ class TimeEntryService {
         private AuditLogService $auditLogService,
         private NotificationService $notificationService,
         private LoggerInterface $logger,
+        private IL10N $l,
     ) {
     }
 
@@ -530,15 +532,15 @@ class TimeEntryService {
         // Check future dates
         $allowFuture = $this->settingsMapper->getValueAsBool(CompanySetting::KEY_ALLOW_FUTURE_ENTRIES);
         if (!$allowFuture && $date > new DateTime('today')) {
-            $errors['date'] = ['Zukünftige Einträge sind nicht erlaubt'];
+            $errors['date'] = [$this->l->t('Zukünftige Einträge sind nicht erlaubt')];
         }
 
         if (!$startTime) {
-            $errors['startTime'] = ['Ungültiges Zeitformat'];
+            $errors['startTime'] = [$this->l->t('Ungültiges Zeitformat')];
         }
 
         if (!$endTime) {
-            $errors['endTime'] = ['Ungültiges Zeitformat'];
+            $errors['endTime'] = [$this->l->t('Ungültiges Zeitformat')];
         }
 
         if ($startTime && $endTime) {
@@ -550,7 +552,7 @@ class TimeEntryService {
             // Check max daily hours
             $maxHours = $this->settingsMapper->getValueAsFloat(CompanySetting::KEY_MAX_DAILY_HOURS);
             if ($grossMinutes / 60 > $maxHours) {
-                $errors['endTime'] = ["Maximale tägliche Arbeitszeit ({$maxHours} Std.) überschritten"];
+                $errors['endTime'] = [$this->l->t('Maximale tägliche Arbeitszeit (%s Std.) überschritten', [(string)$maxHours])];
             }
 
             // Validate break
@@ -558,7 +560,7 @@ class TimeEntryService {
                 $break6h = $this->settingsMapper->getValueAsInt(CompanySetting::KEY_MIN_BREAK_MINUTES_6H);
                 $break9h = $this->settingsMapper->getValueAsInt(CompanySetting::KEY_MIN_BREAK_MINUTES_9H);
                 $minBreak = $grossMinutes > 9 * 60 ? $break9h : $break6h;
-                $errors['breakMinutes'] = ["Mindestpause von {$minBreak} Minuten erforderlich"];
+                $errors['breakMinutes'] = [$this->l->t('Mindestpause von %d Minuten erforderlich', [$minBreak])];
             }
 
             // Check for absence conflict
@@ -571,7 +573,7 @@ class TimeEntryService {
         }
 
         if ($breakMinutes < 0) {
-            $errors['breakMinutes'] = ['Pause kann nicht negativ sein'];
+            $errors['breakMinutes'] = [$this->l->t('Pause kann nicht negativ sein')];
         }
 
         return $errors;
@@ -601,7 +603,7 @@ class TimeEntryService {
                 continue;
             } else {
                 // Full-day absence: block entry completely
-                return "An diesem Tag haben Sie {$absence->getTypeName()}. Bitte stornieren Sie zuerst die Abwesenheit.";
+                return $this->l->t('An diesem Tag haben Sie %s. Bitte stornieren Sie zuerst die Abwesenheit.', [$absence->getTypeName()]);
             }
         }
 
@@ -648,7 +650,7 @@ class TimeEntryService {
             if ($newStart < $existingEnd && $newEnd > $existingStart) {
                 $existingStartStr = $entry->getStartTime()->format('H:i');
                 $existingEndStr = $entry->getEndTime()->format('H:i');
-                return "Überlappung mit bestehendem Eintrag ({$existingStartStr} - {$existingEndStr})";
+                return $this->l->t('Überlappung mit bestehendem Eintrag (%1$s - %2$s)', [$existingStartStr, $existingEndStr]);
             }
         }
 

--- a/lib/Service/WorkScheduleService.php
+++ b/lib/Service/WorkScheduleService.php
@@ -11,6 +11,7 @@ use OCA\WorkTime\Db\EmployeeMapper;
 use OCA\WorkTime\Db\WorkSchedule;
 use OCA\WorkTime\Db\WorkScheduleMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 
 class WorkScheduleService {
@@ -21,6 +22,7 @@ class WorkScheduleService {
         private CompanySettingsService $companySettingsService,
         private AuditLogService $auditLogService,
         private LoggerInterface $logger,
+        private IL10N $l,
     ) {
     }
 
@@ -83,7 +85,7 @@ class WorkScheduleService {
         $firstOfCurrentMonth = new DateTime('first day of this month');
         $firstOfCurrentMonth->setTime(0, 0, 0);
         if ($validFromDate < $firstOfCurrentMonth) {
-            $errors['validFrom'] = ['Gültig-ab darf frühestens der 1. des aktuellen Monats sein'];
+            $errors['validFrom'] = [$this->l->t('Gültig-ab darf frühestens der 1. des aktuellen Monats sein')];
         }
 
         // Check for duplicate valid_from date
@@ -91,7 +93,7 @@ class WorkScheduleService {
             $existingSchedules = $this->mapper->findByEmployeeId($employeeId);
             foreach ($existingSchedules as $existing) {
                 if ($existing->getValidFrom()->format('Y-m-d') === $validFrom) {
-                    $errors['validFrom'] = ['Ein Profil mit diesem Gültig-ab Datum existiert bereits'];
+                    $errors['validFrom'] = [$this->l->t('Ein Profil mit diesem Gültig-ab Datum existiert bereits')];
                     break;
                 }
             }
@@ -119,7 +121,7 @@ class WorkScheduleService {
             $schedule = $this->mapper->insert($schedule);
         } catch (\Exception $e) {
             if (str_contains($e->getMessage(), 'wt_ws_emp_valid_idx') || str_contains($e->getMessage(), 'Unique violation')) {
-                throw new ValidationException(['validFrom' => ['Ein Profil mit diesem Gültig-ab Datum existiert bereits']]);
+                throw new ValidationException(['validFrom' => [$this->l->t('Ein Profil mit diesem Gültig-ab Datum existiert bereits')]]);
             }
             throw $e;
         }
@@ -439,7 +441,7 @@ class WorkScheduleService {
         foreach ($days as $day) {
             $value = (float)($dayHours[$day] ?? 0);
             if ($value < 0 || $value > $maxDailyHours) {
-                $errors[$day] = ["Maximale tägliche Arbeitszeit ist $maxDailyHours Stunden (siehe Einstellungen)"];
+                $errors[$day] = [$this->l->t('Maximale tägliche Arbeitszeit ist %s Stunden (siehe Einstellungen)', [(string)$maxDailyHours])];
             }
         }
 


### PR DESCRIPTION
## Summary

Closes (at least partially) #103.

Several user-facing German source strings in the backend were emitted
directly — bypassing the L10N layer — so even with `lang=en` users
still saw German text in:

- Notification subjects (`Notifier::prepare`)
- Inline validation errors (`TimeEntryService`, `AbsenceService`, `WorkScheduleService`) that are returned as JSON to the frontend and surfaced next to form fields

This PR wires `IL10N` into the three services via constructor injection
and uses `IFactory::get($appId, $languageCode)` inside `Notifier` (so
each recipient gets the notification in **their** language, using the
`$languageCode` argument that `INotifier::prepare()` already receives
from Nextcloud).

`sprintf` positional placeholders (`%1$s`, `%2$s`, …) replace plain
`%s` where multiple arguments are interpolated — this is required for
translators who may need to reorder arguments in target languages.

`l10n/en.json` is extended with entries for every newly wrapped
string, so `en.json` coverage stays complete.

## Scope

**In:**
- `lib/Notification/Notifier.php` — 8 subjects
- `lib/Service/TimeEntryService.php` — 7 inline errors
- `lib/Service/AbsenceService.php` — 3 inline errors
- `lib/Service/WorkScheduleService.php` — 3 inline errors
- `l10n/en.json` — new keys

**Out (deliberately left for a separate, follow-up PR):**
- PDF export labels (`PdfService`) — ~40 strings, needs locale-aware
  month/weekday names too. Bigger change, easier to review on its own.
- The few remaining log/admin messages that aren't user-visible
- `ValidationException` default message (`'Validation failed'`)

Splitting keeps this PR small and focused on what users actually see.

## Test plan

- [x] `php -l` clean on all modified files
- [x] DI container instantiates each affected service (`app:enable worktime` OK)
- [x] Manual check via IFactory::get('worktime', 'en')->t(...) returns English for every new key
- [x] Manual check with 'de' returns the original German source (no regression)
- [ ] Visual: trigger a validation error with user `lang=en` and confirm English text appears in the form (reviewer please verify on your side too)
- [ ] Visual: approve/reject an absence as HR manager for an employee with `lang=en` and confirm the notification subject is English

## Notes

- No changes to database, API contracts, or routes
- No changes to frontend (frontend was already correctly wired through `@nextcloud/l10n`)
- Signed-off by the same commit author as the local fork