### PR TITLE
fix: resolve merge conflict markers in v0.6.2 release files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 - **getStatusLabel() zentralisiert (#117)**: Duplizierte Methode aus TimeEntryRow und AbsenceRow entfernt, zentrale Funktion aus formatters.js verwendet.
 - **ABSENCE_TYPE_LABELS() gecacht (#118)**: Label-Lookup wird einmal pro Abwesenheit aufgerufen statt einmal pro expandiertem Tag.
 
-=======
 ## [0.6.1] - 2026-04-29
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,8 +27,6 @@ Behalten Sie den Überblick über Arbeitszeiten, Überstunden und Urlaub.
     ]]></description>
 
     <version>0.6.2</version>
-=======
-    <version>0.6.1</version>
     <licence>AGPL-3.0-or-later</licence>
 
     <author mail="axel.deffner@cpcmomentum.com" homepage="https://github.com/cpcMomentum">Axel Deffner</author>

--- a/package.json
+++ b/package.json
@@ -1,8 +1,6 @@
 {
     "name": "worktime",
     "version": "0.6.2",
-=======
-    "version": "0.6.1",
     "description": "Nextcloud App zur Arbeitszeiterfassung",
     "main": "src/main.js",
     "scripts": {


### PR DESCRIPTION
Removes leftover conflict markers from info.xml, package.json and CHANGELOG.md that were not fully resolved during the release merge.