### PR TITLE
fix: settings filter for flat key-value array

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -47,8 +47,8 @@ class SettingsController extends BaseController {
         // Non-admins only see public settings
         if (!$this->permissionService->canManageSettings($this->userId)) {
             $allSettings = $this->settingsService->getAll();
-            $filtered = array_filter($allSettings, fn($s) => in_array($s['key'], self::PUBLIC_SETTINGS, true));
-            return $this->successResponse(array_values($filtered));
+            $filtered = array_intersect_key($allSettings, array_flip(self::PUBLIC_SETTINGS));
+            return $this->successResponse($filtered);
         }
 
         return $this->successResponse($this->settingsService->getAll());


### PR DESCRIPTION
Bugfix: `getAll()` returns `['key' => 'value']` (flat), not `[['key' => ..., 'value' => ...]]`.
Uses `array_intersect_key` instead of `array_filter` to correctly filter by key names.

Found during functional testing of PR #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)