### PR TITLE
feat(notification): Mitarbeiter bei Rücknahme der Genehmigung benachrichtigen

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -488,6 +488,7 @@ OC.L10N.register(
     "%1$s hat Zeiteinträge für %2$s zur Genehmigung eingereicht" : "%1$s hat Zeiteinträge für %2$s zur Genehmigung eingereicht",
     "Deine Zeiteinträge für %s wurden genehmigt" : "Deine Zeiteinträge für %s wurden genehmigt",
     "Deine Zeiteinträge für %s wurden abgelehnt" : "Deine Zeiteinträge für %s wurden abgelehnt",
+    "Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen." : "Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen.",
     "Zukünftige Einträge sind nicht erlaubt" : "Zukünftige Einträge sind nicht erlaubt",
     "Ungültiges Zeitformat" : "Ungültiges Zeitformat",
     "Maximale tägliche Arbeitszeit (%s Std.) überschritten" : "Maximale tägliche Arbeitszeit (%s Std.) überschritten",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -487,6 +487,7 @@
 		"%1$s hat Zeiteinträge für %2$s zur Genehmigung eingereicht": "%1$s hat Zeiteinträge für %2$s zur Genehmigung eingereicht",
 		"Deine Zeiteinträge für %s wurden genehmigt": "Deine Zeiteinträge für %s wurden genehmigt",
 		"Deine Zeiteinträge für %s wurden abgelehnt": "Deine Zeiteinträge für %s wurden abgelehnt",
+		"Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen.": "Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen.",
 		"Zukünftige Einträge sind nicht erlaubt": "Zukünftige Einträge sind nicht erlaubt",
 		"Ungültiges Zeitformat": "Ungültiges Zeitformat",
 		"Maximale tägliche Arbeitszeit (%s Std.) überschritten": "Maximale tägliche Arbeitszeit (%s Std.) überschritten",

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -488,6 +488,7 @@ OC.L10N.register(
     "%1$s hat Zeiteinträge für %2$s zur Genehmigung eingereicht" : "%1$s submitted time entries for %2$s for approval",
     "Deine Zeiteinträge für %s wurden genehmigt" : "Your time entries for %s have been approved",
     "Deine Zeiteinträge für %s wurden abgelehnt" : "Your time entries for %s have been rejected",
+    "Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen." : "The approval of your time entries for %s has been revoked. Please submit again.",
     "Zukünftige Einträge sind nicht erlaubt" : "Future entries are not allowed",
     "Ungültiges Zeitformat" : "Invalid time format",
     "Maximale tägliche Arbeitszeit (%s Std.) überschritten" : "Maximum daily working time (%s hours) exceeded",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -487,6 +487,7 @@
 		"%1$s hat Zeiteinträge für %2$s zur Genehmigung eingereicht": "%1$s submitted time entries for %2$s for approval",
 		"Deine Zeiteinträge für %s wurden genehmigt": "Your time entries for %s have been approved",
 		"Deine Zeiteinträge für %s wurden abgelehnt": "Your time entries for %s have been rejected",
+		"Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen.": "The approval of your time entries for %s has been revoked. Please submit again.",
 		"Zukünftige Einträge sind nicht erlaubt": "Future entries are not allowed",
 		"Ungültiges Zeitformat": "Invalid time format",
 		"Maximale tägliche Arbeitszeit (%s Std.) überschritten": "Maximum daily working time (%s hours) exceeded",

--- a/lib/Notification/NotificationService.php
+++ b/lib/Notification/NotificationService.php
@@ -101,6 +101,10 @@ class NotificationService {
 		$this->sendTimeEntryDecisionNotification($employeeId, $year, $month, 'time_entries_rejected');
 	}
 
+	public function notifyTimeEntriesReopened(int $employeeId, int $year, int $month): void {
+		$this->sendTimeEntryDecisionNotification($employeeId, $year, $month, 'time_entries_reopened');
+	}
+
 	private function sendSupervisorAbsenceNotification(Absence $absence, string $subject): void {
 		try {
 			$employee = $this->employeeMapper->find($absence->getEmployeeId());

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -134,6 +134,15 @@ class Notifier implements INotifier {
 				);
 				break;
 
+			case 'time_entries_reopened':
+				$notification->setParsedSubject(
+					$l->t(
+						'Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen.',
+						[$params['monthYear']]
+					)
+				);
+				break;
+
 			default:
 				throw new UnknownNotificationException();
 		}

--- a/lib/Service/TimeEntryService.php
+++ b/lib/Service/TimeEntryService.php
@@ -471,6 +471,10 @@ class TimeEntryService {
             }
         }
 
+        if ($reopened > 0) {
+            $this->notificationService->notifyTimeEntriesReopened($employeeId, $year, $month);
+        }
+
         return [
             'reopened' => $reopened,
             'skipped' => $skipped,


### PR DESCRIPTION
## Ziel (#187)

Folge zu #178 (Genehmigung zurücknehmen). Beim Zurücknehmen einer Monats-Genehmigung gingen die Zeiteinträge zurück auf „Entwurf", ohne dass der **Mitarbeiter informiert** wurde. Jetzt erhält er eine Nextcloud-Benachrichtigung (Glocke), analog zu Genehmigung/Ablehnung.

## Umsetzung (nach bestehendem Vorbild)

- `NotificationService::notifyTimeEntriesReopened()` → `sendTimeEntryDecisionNotification(..., 'time_entries_reopened')`
- `Notifier`: neuer `case 'time_entries_reopened'` mit übersetztem Subject (Parameter `monthYear`)
- `TimeEntryService::reopenMonth()` ruft die Benachrichtigung auf, wenn `reopened > 0`
- l10n in allen 4 Dateien (de/en × js/json)

Empfänger ist der betroffene Mitarbeiter (`employee->getUserId()`), nicht der auslösende HR/Admin. Fehler beim Versand werden geloggt (bestehendes try/catch in `sendTimeEntryDecisionNotification`), der Reopen-Workflow bleibt davon unberührt.

## Verifikation (Playwright, lokal Docker NC 33, lang=en)

Szenario: Mitarbeiter mit genehmigtem Mai-Monat → „Revoke approval" mit Begründung.
- Benachrichtigung erscheint in der Glocke: **„The approval of your time entries for Mai 2026 has been revoked. Please submit again."** ✓
- PHP-Lint sauber, OCP-only, JSON/JS valide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)