### PR TITLE
fix(pdf): wrap long notes in time-entries and absences tables

### DIFF
--- a/lib/Service/PdfService.php
+++ b/lib/Service/PdfService.php
@@ -218,34 +218,46 @@ class PdfService {
             if (isset($entriesByDate[$dateStr])) {
                 // Has time entries
                 foreach ($entriesByDate[$dateStr] as $entry) {
-                    $pdf->Cell(25, 6, $dateFormatted, 1, 0, 'C', $fill);
-                    $pdf->Cell(15, 6, $dayName, 1, 0, 'C', $fill);
-                    $pdf->Cell(20, 6, $entry->getStartTime()->format('H:i'), 1, 0, 'C', $fill);
-                    $pdf->Cell(20, 6, $entry->getEndTime()->format('H:i'), 1, 0, 'C', $fill);
-                    $pdf->Cell(20, 6, $this->formatMinutes($entry->getBreakMinutes()), 1, 0, 'C', $fill);
-                    $pdf->Cell(20, 6, $this->formatMinutes($entry->getWorkMinutes()), 1, 0, 'C', $fill);
-                    $pdf->Cell(0, 6, $entry->getDescription() ?? '', 1, 1, 'L', $fill);
+                    $this->renderTimeEntryRow(
+                        $pdf,
+                        $dateFormatted,
+                        $dayName,
+                        $entry->getStartTime()->format('H:i'),
+                        $entry->getEndTime()->format('H:i'),
+                        $this->formatMinutes($entry->getBreakMinutes()),
+                        $this->formatMinutes($entry->getWorkMinutes()),
+                        $entry->getDescription() ?? '',
+                        $fill
+                    );
                     $dateFormatted = ''; // Clear for subsequent entries on same day
                     $dayName = '';
                 }
             } elseif ($isHoliday) {
                 // Holiday
-                $pdf->Cell(25, 6, $dateFormatted, 1, 0, 'C', $fill);
-                $pdf->Cell(15, 6, $dayName, 1, 0, 'C', $fill);
-                $pdf->Cell(20, 6, '-', 1, 0, 'C', $fill);
-                $pdf->Cell(20, 6, '-', 1, 0, 'C', $fill);
-                $pdf->Cell(20, 6, '-', 1, 0, 'C', $fill);
-                $pdf->Cell(20, 6, '-', 1, 0, 'C', $fill);
-                $pdf->Cell(0, 6, 'Feiertag: ' . $holidayDates[$dateStr], 1, 1, 'L', $fill);
+                $this->renderTimeEntryRow(
+                    $pdf,
+                    $dateFormatted,
+                    $dayName,
+                    '-',
+                    '-',
+                    '-',
+                    '-',
+                    'Feiertag: ' . $holidayDates[$dateStr],
+                    $fill
+                );
             } elseif (!$isWeekend) {
                 // Regular workday without entry
-                $pdf->Cell(25, 6, $dateFormatted, 1, 0, 'C', $fill);
-                $pdf->Cell(15, 6, $dayName, 1, 0, 'C', $fill);
-                $pdf->Cell(20, 6, '', 1, 0, 'C', $fill);
-                $pdf->Cell(20, 6, '', 1, 0, 'C', $fill);
-                $pdf->Cell(20, 6, '', 1, 0, 'C', $fill);
-                $pdf->Cell(20, 6, '', 1, 0, 'C', $fill);
-                $pdf->Cell(0, 6, '', 1, 1, 'L', $fill);
+                $this->renderTimeEntryRow(
+                    $pdf,
+                    $dateFormatted,
+                    $dayName,
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    $fill
+                );
             }
 
             $current->modify('+1 day');
@@ -283,14 +295,76 @@ class PdfService {
             ];
             $status = $statusTranslation[$absence->getStatus()] ?? $absence->getStatus();
 
-            $pdf->Cell(30, 6, $period, 1, 0, 'C');
-            $pdf->Cell(20, 6, $days, 1, 0, 'C');
-            $pdf->Cell(30, 6, $absence->getTypeName(), 1, 0, 'L');
-            $pdf->Cell(25, 6, $status, 1, 0, 'C');
-            $pdf->Cell(0, 6, $absence->getNote() ?? '', 1, 1, 'L');
+            $this->renderAbsenceRow($pdf, $period, $days, $absence->getTypeName(), $status, $absence->getNote() ?? '');
         }
 
         $pdf->Ln(5);
+    }
+
+    /**
+     * Width of the note column = page width minus margins and the sum of the fixed columns.
+     */
+    private function getNoteCellWidth(TCPDF $pdf, float $fixedColumnsWidth): float {
+        $margins = $pdf->getMargins();
+        return $pdf->getPageWidth() - $margins['left'] - $margins['right'] - $fixedColumnsWidth;
+    }
+
+    /**
+     * Calculate the row height needed so a wrapping note fits, with $minHeight as the floor.
+     */
+    private function calculateRowHeight(TCPDF $pdf, string $note, float $noteWidth, float $minHeight = 6.0): float {
+        if ($note === '') {
+            return $minHeight;
+        }
+        return max($minHeight, $pdf->getStringHeight($noteWidth, $note));
+    }
+
+    /**
+     * Render one row of the time entries table; the note column wraps and dictates row height.
+     */
+    private function renderTimeEntryRow(
+        TCPDF $pdf,
+        string $date,
+        string $day,
+        string $start,
+        string $end,
+        string $break,
+        string $work,
+        string $note,
+        bool $fill
+    ): void {
+        $noteWidth = $this->getNoteCellWidth($pdf, 120.0);
+        $rowHeight = $this->calculateRowHeight($pdf, $note, $noteWidth);
+
+        $pdf->Cell(25, $rowHeight, $date, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
+        $pdf->Cell(15, $rowHeight, $day, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
+        $pdf->Cell(20, $rowHeight, $start, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
+        $pdf->Cell(20, $rowHeight, $end, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
+        $pdf->Cell(20, $rowHeight, $break, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
+        $pdf->Cell(20, $rowHeight, $work, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
+        $pdf->MultiCell($noteWidth, $rowHeight, $note, 1, 'L', $fill, 1, '', '', true, 0, false, true, 0, 'M');
+    }
+
+    /**
+     * Render one row of the absences table; the note column wraps and dictates row height.
+     */
+    private function renderAbsenceRow(
+        TCPDF $pdf,
+        string $period,
+        string $days,
+        string $type,
+        string $status,
+        string $note,
+        bool $fill = false
+    ): void {
+        $noteWidth = $this->getNoteCellWidth($pdf, 105.0);
+        $rowHeight = $this->calculateRowHeight($pdf, $note, $noteWidth);
+
+        $pdf->Cell(30, $rowHeight, $period, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
+        $pdf->Cell(20, $rowHeight, $days, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
+        $pdf->Cell(30, $rowHeight, $type, 1, 0, 'L', $fill, '', 0, false, 'T', 'M');
+        $pdf->Cell(25, $rowHeight, $status, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
+        $pdf->MultiCell($noteWidth, $rowHeight, $note, 1, 'L', $fill, 1, '', '', true, 0, false, true, 0, 'M');
     }
 
     /**

--- a/lib/Service/PdfService.php
+++ b/lib/Service/PdfService.php
@@ -310,13 +310,22 @@ class PdfService {
     }
 
     /**
-     * Calculate the row height needed so a wrapping note fits, with $minHeight as the floor.
+     * Calculate the row height needed so a wrapping note fits, with $lineHeight as the per-line floor.
+     *
+     * getStringHeight() returns the *total* height for all wrapped lines; we count lines from it
+     * so that the fixed Cell() siblings and MultiCell($h=$lineHeight) agree on the row height.
      */
-    private function calculateRowHeight(TCPDF $pdf, string $note, float $noteWidth, float $minHeight = 6.0): float {
+    private function calculateRowHeight(TCPDF $pdf, string $note, float $noteWidth, float $lineHeight = 6.0): float {
         if ($note === '') {
-            return $minHeight;
+            return $lineHeight;
         }
-        return max($minHeight, $pdf->getStringHeight($noteWidth, $note));
+        $singleLineHeight = $pdf->getStringHeight($noteWidth, 'A');
+        if ($singleLineHeight <= 0.0) {
+            return $lineHeight;
+        }
+        $totalNoteHeight = $pdf->getStringHeight($noteWidth, $note);
+        $numLines = max(1, (int)round($totalNoteHeight / $singleLineHeight));
+        return max($lineHeight, $numLines * $lineHeight);
     }
 
     /**
@@ -333,8 +342,9 @@ class PdfService {
         string $note,
         bool $fill
     ): void {
+        $lineHeight = 6.0;
         $noteWidth = $this->getNoteCellWidth($pdf, 120.0);
-        $rowHeight = $this->calculateRowHeight($pdf, $note, $noteWidth);
+        $rowHeight = $this->calculateRowHeight($pdf, $note, $noteWidth, $lineHeight);
 
         $pdf->Cell(25, $rowHeight, $date, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(15, $rowHeight, $day, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
@@ -342,7 +352,8 @@ class PdfService {
         $pdf->Cell(20, $rowHeight, $end, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(20, $rowHeight, $break, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(20, $rowHeight, $work, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
-        $pdf->MultiCell($noteWidth, $rowHeight, $note, 1, 'L', $fill, 1, '', '', true, 0, false, true, 0, 'M');
+        // $h must be the per-line height (not the total): MultiCell height = numLines × $lineHeight = $rowHeight
+        $pdf->MultiCell($noteWidth, $lineHeight, $note, 1, 'L', $fill, 1, '', '', true, 0, false, true, 0, 'M');
     }
 
     /**
@@ -357,14 +368,16 @@ class PdfService {
         string $note,
         bool $fill = false
     ): void {
+        $lineHeight = 6.0;
         $noteWidth = $this->getNoteCellWidth($pdf, 105.0);
-        $rowHeight = $this->calculateRowHeight($pdf, $note, $noteWidth);
+        $rowHeight = $this->calculateRowHeight($pdf, $note, $noteWidth, $lineHeight);
 
         $pdf->Cell(30, $rowHeight, $period, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(20, $rowHeight, $days, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(30, $rowHeight, $type, 1, 0, 'L', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(25, $rowHeight, $status, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
-        $pdf->MultiCell($noteWidth, $rowHeight, $note, 1, 'L', $fill, 1, '', '', true, 0, false, true, 0, 'M');
+        // $h must be the per-line height (not the total): MultiCell height = numLines × $lineHeight = $rowHeight
+        $pdf->MultiCell($noteWidth, $lineHeight, $note, 1, 'L', $fill, 1, '', '', true, 0, false, true, 0, 'M');
     }
 
     /**

--- a/lib/Service/PdfService.php
+++ b/lib/Service/PdfService.php
@@ -310,22 +310,13 @@ class PdfService {
     }
 
     /**
-     * Calculate the row height needed so a wrapping note fits, with $lineHeight as the per-line floor.
-     *
-     * getStringHeight() returns the *total* height for all wrapped lines; we count lines from it
-     * so that the fixed Cell() siblings and MultiCell($h=$lineHeight) agree on the row height.
+     * Calculate the row height needed so a wrapping note fits, with $minHeight as the floor.
      */
-    private function calculateRowHeight(TCPDF $pdf, string $note, float $noteWidth, float $lineHeight = 6.0): float {
+    private function calculateRowHeight(TCPDF $pdf, string $note, float $noteWidth, float $minHeight = 6.0): float {
         if ($note === '') {
-            return $lineHeight;
+            return $minHeight;
         }
-        $singleLineHeight = $pdf->getStringHeight($noteWidth, 'A');
-        if ($singleLineHeight <= 0.0) {
-            return $lineHeight;
-        }
-        $totalNoteHeight = $pdf->getStringHeight($noteWidth, $note);
-        $numLines = max(1, (int)round($totalNoteHeight / $singleLineHeight));
-        return max($lineHeight, $numLines * $lineHeight);
+        return max($minHeight, $pdf->getStringHeight($noteWidth, $note));
     }
 
     /**
@@ -342,9 +333,8 @@ class PdfService {
         string $note,
         bool $fill
     ): void {
-        $lineHeight = 6.0;
         $noteWidth = $this->getNoteCellWidth($pdf, 120.0);
-        $rowHeight = $this->calculateRowHeight($pdf, $note, $noteWidth, $lineHeight);
+        $rowHeight = $this->calculateRowHeight($pdf, $note, $noteWidth);
 
         $pdf->Cell(25, $rowHeight, $date, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(15, $rowHeight, $day, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
@@ -352,8 +342,7 @@ class PdfService {
         $pdf->Cell(20, $rowHeight, $end, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(20, $rowHeight, $break, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(20, $rowHeight, $work, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
-        // $h must be the per-line height (not the total): MultiCell height = numLines × $lineHeight = $rowHeight
-        $pdf->MultiCell($noteWidth, $lineHeight, $note, 1, 'L', $fill, 1, '', '', true, 0, false, true, 0, 'M');
+        $pdf->MultiCell($noteWidth, $rowHeight, $note, 1, 'L', $fill, 1, '', '', true, 0, false, true, 0, 'M');
     }
 
     /**
@@ -368,16 +357,14 @@ class PdfService {
         string $note,
         bool $fill = false
     ): void {
-        $lineHeight = 6.0;
         $noteWidth = $this->getNoteCellWidth($pdf, 105.0);
-        $rowHeight = $this->calculateRowHeight($pdf, $note, $noteWidth, $lineHeight);
+        $rowHeight = $this->calculateRowHeight($pdf, $note, $noteWidth);
 
         $pdf->Cell(30, $rowHeight, $period, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(20, $rowHeight, $days, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(30, $rowHeight, $type, 1, 0, 'L', $fill, '', 0, false, 'T', 'M');
         $pdf->Cell(25, $rowHeight, $status, 1, 0, 'C', $fill, '', 0, false, 'T', 'M');
-        // $h must be the per-line height (not the total): MultiCell height = numLines × $lineHeight = $rowHeight
-        $pdf->MultiCell($noteWidth, $lineHeight, $note, 1, 'L', $fill, 1, '', '', true, 0, false, true, 0, 'M');
+        $pdf->MultiCell($noteWidth, $rowHeight, $note, 1, 'L', $fill, 1, '', '', true, 0, false, true, 0, 'M');
     }
 
     /**


### PR DESCRIPTION
## Summary

Behebt Issue #203: Lange Texte in der "Bemerkungen"-Spalte des PDF-Arbeitszeitnachweises liefen über die Zellgrenze hinaus und konnten bis über den Seitenrand reichen.

**Root Cause:** Die Bemerkungs-Spalte wurde mit `TCPDF::Cell()` gerendert — einzeilig, ohne Umbruch.

**Fix:** Umstellung der Notes-Spalte auf `MultiCell` mit dynamisch berechneter Zeilenhöhe (`TCPDF::getStringHeight()` auf die tatsächliche Spaltenbreite). Die übrigen Zellen derselben Zeile werden auf dieselbe Höhe gestreckt mit `valign='M'` (mittig), damit das Tabellenraster intakt bleibt.

Vier Stellen umgestellt — drei Pfade in `addTimeEntriesTable` (Entry, Holiday, Empty-Workday) und einer in `addAbsencesSection` — gekapselt in zwei neue Helper `renderTimeEntryRow()` / `renderAbsenceRow()` plus zwei kleine Utility-Methoden (`getNoteCellWidth`, `calculateRowHeight`).

## Test plan

- [x] PHP-Syntax-Check (Docker `php -l`)
- [x] OCP-only Check (kein `OC_*`/`\OC\`)
- [x] Lokaler PDF-Smoke-Test: Admin-User mit Mix aus Einträgen (28.05. mittlerer Text, 29.05. langer Text >300 Zeichen), Feiertagen (01.05. Tag der Arbeit, 14.05. Christi Himmelfahrt), leeren Arbeitstagen und Abwesenheiten (Kurzurlaub, Krankmeldung mit langer Bemerkung) → Mai-2026-Report generiert. Beide Tabellen umbrechen korrekt, kurze Notizen bleiben einzeilig, leere Bemerkungen unverändert, Tabellenraster intakt.
- [ ] Auf VPS getestet (per Memory: Produktiv läuft App-Store-Version → wird automatisch durch nächstes Patch-Release ausgeliefert)

## Risk

Niedrig — lokal isolierte PHP-Änderung in einer Service-Klasse, kein DB- oder API-Schema-Change, kein Frontend-Touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)