### PR TITLE
fix(l10n): correct Czech plural header to nplurals=3

### DIFF
--- a/l10n/cs.js
+++ b/l10n/cs.js
@@ -565,4 +565,4 @@ OC.L10N.register(
         "Tage übrig": "Zbývající dny",
         "Stand heute": "Ke dnešnímu dni"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;");

--- a/l10n/cs.json
+++ b/l10n/cs.json
@@ -564,5 +564,5 @@
 		"Tage übrig": "Zbývající dny",
 		"Stand heute": "Ke dnešnímu dni"
 	},
-	"pluralForm": "nplurals=2; plural=(n != 1);"
+	"pluralForm": "nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;"
 }


### PR DESCRIPTION
## Summary
Follow-up to #258. The Czech translation shipped with the German/English plural rule `nplurals=2; plural=(n != 1);`. Czech has three plural forms, so this replaces it with the standard CLDR rule in both `cs.js` and `cs.json`:

```
nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;
```

No functional change today (the app currently has no plural strings), but the header is now correct for when plural forms are introduced. As promised to the contributor in the #258 review.

## Test plan
- [x] `cs.json` still valid JSON
- [x] `cs.js` passes `node --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)