### PR TITLE
ci: fetch-depth 0 für Claude-Workflows (Diff-Merge-Base-Fix)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,7 +59,9 @@ jobs:
         if: steps.cycles.outputs.count < 3 && steps.cycles.outputs.last_status != 'APPROVED'
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # Volle Historie: der Reviewer berechnet den PR-Diff via base...HEAD,
+          # das braucht den Base-Branch + Merge-Base (sonst "no merge base").
+          fetch-depth: 0
           ref: ${{ github.head_ref }}
 
       - name: Run Claude Code Review & Auto-Fix

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # Volle Historie: Claude berechnet Diffs via base...HEAD und braucht
+          # den Base-Branch + Merge-Base (sonst "no merge base" auf flachem Clone).
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Problem
Der `claude-review`-Workflow schlug bei PR #263 fehl: `Reached maximum number of turns (50)`.

**Ursache (kein Secret-Problem):** OAuth-Token + Auth funktionieren. Aber der Reviewer berechnet den PR-Diff via `git diff base...HEAD`, und der Checkout mit `fetch-depth: 1` liefert weder Base-Branch noch Merge-Base → `fatal: origin/develop...HEAD: no merge base`. Der Agent probiert immer weiter, verbraucht alle Turns, Run bricht ab. Vermutlich durch eine neue `@v1`-Version der Action ausgelöst (fließendes Tag).

## Fix
`fetch-depth: 0` in beiden Workflows (`claude-code-review.yml`, `claude.yml`) → volle Historie inkl. aller Branches, Merge-Base verfügbar.

## Selbsttest
Dieser PR triggert `claude-review` mit der **gefixten** Workflow-Version (Head-Branch). Wenn der Bot hier ein normales Review postet, ist der Fix bestätigt.