### PR TITLE
fix(vacation): Urlaubsanspruch konsistent aus gültigem Profil (#281)

### DIFF
--- a/lib/Service/WorkScheduleService.php
+++ b/lib/Service/WorkScheduleService.php
@@ -322,29 +322,31 @@ class WorkScheduleService {
 
     /**
      * Get vacation days entitlement for a year.
-     * Pro-rates across multiple schedules if profile changes occur mid-year.
+     *
+     * Vacation entitlement is an annual figure tied to the work-schedule profile
+     * that is valid for the employee, not a value that accrues per sub-period the
+     * way working hours do. Pro-rating it across mid-year profile changes produced
+     * confusing blended numbers that disagreed with the profile editor and the
+     * employee overview (#281) – e.g. an auto-created default profile (30 days)
+     * overlapping a real, mid-year profile (14 days) showed ~21 instead of 14.
+     *
+     * We therefore take the entitlement from the profile valid at the year's
+     * reference date: today for the current year (so it matches the employee
+     * overview and profile editor), the year's end for past years.
      */
     public function getVacationDaysForYear(int $employeeId, int $year): int {
-        $jan1 = new DateTime("$year-01-01");
-        $dec31 = new DateTime("$year-12-31");
-        $segments = $this->buildSegments($employeeId, $jan1, $dec31);
+        $now = new DateTime();
+        $yearStart = new DateTime("$year-01-01");
+        $yearEnd = new DateTime("$year-12-31");
 
-        // Nur ein Profil das ganze Jahr → direkt zurueckgeben
-        if (count($segments) === 1) {
-            return $segments[0]['schedule']->getVacationDays();
+        // The year's end, but never in the future: the current year uses the
+        // profile valid today; a future year falls back to the year's start.
+        $reference = $yearEnd < $now ? $yearEnd : $now;
+        if ($reference < $yearStart) {
+            $reference = $yearStart;
         }
 
-        // Mehrere Profile → anteilig berechnen
-        $daysInYear = (int)$jan1->diff($dec31)->days + 1;
-        $totalDays = 0.0;
-
-        foreach ($segments as $segment) {
-            $daysInSegment = (int)$segment['start']->diff($segment['end'])->days + 1;
-            $fraction = $daysInSegment / $daysInYear;
-            $totalDays += $segment['schedule']->getVacationDays() * $fraction;
-        }
-
-        return (int)round($totalDays);
+        return $this->getScheduleForDate($employeeId, $reference)->getVacationDays();
     }
 
     /**

--- a/tests/Unit/Service/WorkScheduleServiceTest.php
+++ b/tests/Unit/Service/WorkScheduleServiceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Tests\Unit\Service;
+
+use DateTime;
+use OCA\WorkTime\Db\WorkSchedule;
+use OCA\WorkTime\Db\WorkScheduleMapper;
+use OCA\WorkTime\Db\EmployeeMapper;
+use OCA\WorkTime\Service\AuditLogService;
+use OCA\WorkTime\Service\CompanySettingsService;
+use OCA\WorkTime\Service\WorkScheduleService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IL10N;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Regression coverage for issue #281: the annual vacation entitlement must equal
+ * the value of the work-schedule profile that is valid for the year, identical
+ * across the profile editor, the employee overview and the team view. It must
+ * NOT be pro-rated/blended across an overlapping (e.g. auto-created default)
+ * profile, which previously produced surprising numbers such as 21 instead of 14.
+ */
+class WorkScheduleServiceTest extends TestCase {
+
+    private WorkScheduleService $service;
+    private WorkScheduleMapper $mapper;
+
+    protected function setUp(): void {
+        $this->mapper = $this->createMock(WorkScheduleMapper::class);
+
+        $this->service = new WorkScheduleService(
+            $this->mapper,
+            $this->createMock(EmployeeMapper::class),
+            $this->createMock(CompanySettingsService::class),
+            $this->createMock(AuditLogService::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(IL10N::class),
+        );
+    }
+
+    private function schedule(int $vacationDays): WorkSchedule {
+        $s = new WorkSchedule();
+        $s->setEmployeeId(1);
+        $s->setValidFrom(new DateTime('2020-01-01'));
+        $s->setVacationDays($vacationDays);
+        return $s;
+    }
+
+    /**
+     * The entitlement equals the valid profile's value – not a blend with any
+     * earlier/overlapping profile. We query a past year so the reference date is
+     * deterministic (the year's end), independent of the current date.
+     */
+    public function testReturnsValidProfileVacationDaysWithoutBlending(): void {
+        $pastYear = (int)(new DateTime())->format('Y') - 1;
+
+        // Whatever date is asked for in that year, the valid profile has 14 days.
+        $this->mapper->method('findForDate')->willReturn($this->schedule(14));
+
+        $this->assertSame(14, $this->service->getVacationDaysForYear(1, $pastYear));
+    }
+
+    /**
+     * With no persisted schedule, getScheduleForDate falls back to a default
+     * (30 days), so the entitlement is the default rather than an error.
+     */
+    public function testFallsBackToDefaultWhenNoScheduleExists(): void {
+        $pastYear = (int)(new DateTime())->format('Y') - 1;
+
+        $this->mapper->method('findForDate')
+            ->willThrowException(new DoesNotExistException('none'));
+
+        $this->assertSame(30, $this->service->getVacationDaysForYear(1, $pastYear));
+    }
+
+    /**
+     * For a past year the reference date is that year's 31 December, ensuring the
+     * profile valid back then drives the entitlement.
+     */
+    public function testPastYearUsesYearEndAsReference(): void {
+        $pastYear = (int)(new DateTime())->format('Y') - 1;
+        $expectedReference = $pastYear . '-12-31';
+
+        $this->mapper->expects($this->once())
+            ->method('findForDate')
+            ->with(
+                $this->equalTo(1),
+                $this->callback(fn (DateTime $d): bool => $d->format('Y-m-d') === $expectedReference),
+            )
+            ->willReturn($this->schedule(20));
+
+        $this->assertSame(20, $this->service->getVacationDaysForYear(1, $pastYear));
+    }
+}


### PR DESCRIPTION
## Problem

Der Urlaubsanspruch wurde in verschiedenen Ansichten unterschiedlich angezeigt: Der Profil-Editor zeigte z. B. 14 Tage, die Team-/Mitarbeiter-Ansicht aber 21. Gemeldet in #281 (Udo) und unabhängig per Mail von einer Teilzeit-Einrichtung (Umstieg Mitte 2026).

## Root Cause (empirisch reproduziert)

`WorkScheduleService::getVacationDaysForYear()` pro-ratete den Jahresanspruch über alle Arbeitszeitprofile eines Jahres. Beim Anlegen eines Mitarbeiters entsteht automatisch ein Initial-Profil mit Default **30** Urlaubstagen. Wird das echte Profil später mit einem Startdatum mitten im Jahr gesetzt, überlappen sich zwei Profile und der Anspruch wird gemittelt:

| Profil A (ab 2020) | Profil B (ab 01.05.2026) | Carryover | vorher | nachher |
|---|---|---|---|---|
| 30 Tage | 24 Tage | 1 | **27** | **25** |

(„Bei 30 Urlaubstagen funktioniert es meistens" — weil 30 == Default, keine Abweichung.)

## Fix

Urlaubsanspruch ist eine Jahresgröße, kein anteilig akkumulierender Wert wie Arbeitsstunden. Er wird jetzt aus dem **am Stichtag gültigen Profil** genommen (heute fürs laufende Jahr, Jahresende für vergangene Jahre) — kein Blending. Profil-Editor, Mitarbeiter- und Team-Ansicht zeigen denselben Wert; bestehende Daten heilen automatisch. Pro-rata bleibt für Soll-Stunden (`countWorkingDays`) erhalten.

## Verifikation

- Empirisch über den echten Code-Pfad (NC-gebootstrappt): 30+24-Profil + 1 Carryover → **25** statt 27.
- 3 Regressionstests (`WorkScheduleServiceTest`) grün.

Fixes #281
