### PR TITLE
chore(l10n): verwaisten Quota-String entfernen

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -208,7 +208,6 @@ OC.L10N.register(
     "½ Tag" : "½ Tag",
     "1 Tag" : "1 Tag",
     "Halber Tag = 0,5 Tage. Start- und Enddatum sind identisch." : "Halber Tag = 0,5 Tage. Start- und Enddatum sind identisch.",
-    "Nicht genügend Urlaubstage. Verfügbar: {available}, beantragt: {requested}." : "Nicht genügend Urlaubstage. Verfügbar: {available}, beantragt: {requested}.",
     "Startdatum" : "Startdatum",
     "Enddatum" : "Enddatum",
     "Von" : "Von",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -207,7 +207,6 @@
 		"½ Tag": "½ Tag",
 		"1 Tag": "1 Tag",
 		"Halber Tag = 0,5 Tage. Start- und Enddatum sind identisch.": "Halber Tag = 0,5 Tage. Start- und Enddatum sind identisch.",
-		"Nicht genügend Urlaubstage. Verfügbar: {available}, beantragt: {requested}.": "Nicht genügend Urlaubstage. Verfügbar: {available}, beantragt: {requested}.",
 		"Startdatum": "Startdatum",
 		"Enddatum": "Enddatum",
 		"Von": "Von",

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -207,7 +207,6 @@ OC.L10N.register(
     "½ Tag" : "½ day",
     "1 Tag" : "1 day",
     "Halber Tag = 0,5 Tage. Start- und Enddatum sind identisch." : "Half day = 0.5 days. Start and end date are identical.",
-    "Nicht genügend Urlaubstage. Verfügbar: {available}, beantragt: {requested}." : "Not enough vacation days. Available: {available}, requested: {requested}.",
     "Startdatum" : "Start Date",
     "Enddatum" : "End Date",
     "Von" : "From",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -206,7 +206,6 @@
 		"½ Tag": "½ day",
 		"1 Tag": "1 day",
 		"Halber Tag = 0,5 Tage. Start- und Enddatum sind identisch.": "Half day = 0.5 days. Start and end date are identical.",
-		"Nicht genügend Urlaubstage. Verfügbar: {available}, beantragt: {requested}.": "Not enough vacation days. Available: {available}, requested: {requested}.",
 		"Startdatum": "Start Date",
 		"Enddatum": "End Date",
 		"Von": "From",


### PR DESCRIPTION
Entfernt den nach #282 ungenutzten l10n-Key `"Nicht genügend Urlaubstage. Verfügbar: {available}, beantragt: {requested}."` aus en/de (.js + .json). Vom Bot-Review zu #285 als totes l10n-Rauschen markiert. Keine Funktionsänderung.