### PR TITLE
feat(#148): HR-Korrekturworkflow — Backend-Fundament (Sperre + HR-Override + Reopen)

### DIFF
--- a/l10n/cs.js
+++ b/l10n/cs.js
@@ -471,7 +471,6 @@ OC.L10N.register(
         "Überlappung mit bestehendem Eintrag (%1$s - %2$s)": "Překryv se stávajícím záznamem (%1$s - %2$s)",
         "Scope muss zwischen 0 und 1 liegen": "Rozsah musí být mezi 0 a 1",
         "Halber Tag ist nur für einen einzelnen Tag möglich": "Půlden je možný pouze pro jeden den",
-        "Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)": "Den %1$s nelze odstranit (měsíc %2$02d/%3$d je schválen)",
         "Gültig-ab darf frühestens der 1. des aktuellen Monats sein": "Platnost-od může být nejdříve 1. den aktuálního měsíce",
         "Ein Profil mit diesem Gültig-ab Datum existiert bereits": "Profil s tímto datem platnosti-od již existuje",
         "Maximale tägliche Arbeitszeit ist %s Stunden (siehe Einstellungen)": "Maximální denní pracovní doba je %s hodin (viz nastavení)",

--- a/l10n/cs.json
+++ b/l10n/cs.json
@@ -470,7 +470,6 @@
 		"Überlappung mit bestehendem Eintrag (%1$s - %2$s)": "Překryv se stávajícím záznamem (%1$s - %2$s)",
 		"Scope muss zwischen 0 und 1 liegen": "Rozsah musí být mezi 0 a 1",
 		"Halber Tag ist nur für einen einzelnen Tag möglich": "Půlden je možný pouze pro jeden den",
-		"Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)": "Den %1$s nelze odstranit (měsíc %2$02d/%3$d je schválen)",
 		"Gültig-ab darf frühestens der 1. des aktuellen Monats sein": "Platnost-od může být nejdříve 1. den aktuálního měsíce",
 		"Ein Profil mit diesem Gültig-ab Datum existiert bereits": "Profil s tímto datem platnosti-od již existuje",
 		"Maximale tägliche Arbeitszeit ist %s Stunden (siehe Einstellungen)": "Maximální denní pracovní doba je %s hodin (viz nastavení)",

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -528,7 +528,6 @@ OC.L10N.register(
     "Überlappung mit bestehendem Eintrag (%1$s - %2$s)" : "Überlappung mit bestehendem Eintrag (%1$s - %2$s)",
     "Scope muss zwischen 0 und 1 liegen" : "Scope muss zwischen 0 und 1 liegen",
     "Halber Tag ist nur für einen einzelnen Tag möglich" : "Halber Tag ist nur für einen einzelnen Tag möglich",
-    "Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)" : "Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)",
     "Gültig-ab darf frühestens der 1. des aktuellen Monats sein" : "Gültig-ab darf frühestens der 1. des aktuellen Monats sein",
     "Ein Profil mit diesem Gültig-ab Datum existiert bereits" : "Ein Profil mit diesem Gültig-ab Datum existiert bereits",
     "Maximale tägliche Arbeitszeit ist %s Stunden (siehe Einstellungen)" : "Maximale tägliche Arbeitszeit ist %s Stunden (siehe Einstellungen)",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -527,7 +527,6 @@
 		"Überlappung mit bestehendem Eintrag (%1$s - %2$s)": "Überlappung mit bestehendem Eintrag (%1$s - %2$s)",
 		"Scope muss zwischen 0 und 1 liegen": "Scope muss zwischen 0 und 1 liegen",
 		"Halber Tag ist nur für einen einzelnen Tag möglich": "Halber Tag ist nur für einen einzelnen Tag möglich",
-		"Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)": "Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)",
 		"Gültig-ab darf frühestens der 1. des aktuellen Monats sein": "Gültig-ab darf frühestens der 1. des aktuellen Monats sein",
 		"Ein Profil mit diesem Gültig-ab Datum existiert bereits": "Ein Profil mit diesem Gültig-ab Datum existiert bereits",
 		"Maximale tägliche Arbeitszeit ist %s Stunden (siehe Einstellungen)": "Maximale tägliche Arbeitszeit ist %s Stunden (siehe Einstellungen)",

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -528,7 +528,6 @@ OC.L10N.register(
     "Überlappung mit bestehendem Eintrag (%1$s - %2$s)" : "Overlap with existing entry (%1$s - %2$s)",
     "Scope muss zwischen 0 und 1 liegen" : "Scope must be between 0 and 1",
     "Halber Tag ist nur für einen einzelnen Tag möglich" : "Half day is only possible for a single day",
-    "Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)" : "Day %1$s cannot be removed (month %2$02d/%3$d is approved)",
     "Gültig-ab darf frühestens der 1. des aktuellen Monats sein" : "Valid-from must be no earlier than the 1st of the current month",
     "Ein Profil mit diesem Gültig-ab Datum existiert bereits" : "A profile with this valid-from date already exists",
     "Maximale tägliche Arbeitszeit ist %s Stunden (siehe Einstellungen)" : "Maximum daily working time is %s hours (see settings)",
@@ -567,6 +566,8 @@ OC.L10N.register(
     "Freizeitausgleich reduziert die Überstunden automatisch." : "Compensatory leave automatically reduces overtime.",
     "Freizeitausgleich genommen" : "Compensatory time taken",
     "Hinweis: Der Zeitraum umfasst ca. {requested} Werktage (Resturlaub: {available}). Abgezogen werden nur deine Arbeitstage laut Arbeitszeitmodell – bei Teilzeit also weniger." : "Note: the period spans approx. {requested} working days (remaining: {available}). Only your working days according to your work schedule are deducted – fewer for part-time.",
-    "Hinweis: ca. {requested} Werktage im Zeitraum (Resturlaub: {available}). Abgezogen werden nur Arbeitstage laut Arbeitszeitmodell." : "Note: approx. {requested} working days in the period (remaining: {available}). Only working days according to the work schedule are deducted."
+    "Hinweis: ca. {requested} Werktage im Zeitraum (Resturlaub: {available}). Abgezogen werden nur Arbeitstage laut Arbeitszeitmodell." : "Note: approx. {requested} working days in the period (remaining: {available}). Only working days according to the work schedule are deducted.",
+    "Dieser Zeitraum ist abgeschlossen. Bitte wende dich an HR." : "This period is closed. Please contact HR.",
+    "Begründung erforderlich (mindestens 10 Zeichen)." : "A reason is required (at least 10 characters)."
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -527,7 +527,6 @@
 		"Überlappung mit bestehendem Eintrag (%1$s - %2$s)": "Overlap with existing entry (%1$s - %2$s)",
 		"Scope muss zwischen 0 und 1 liegen": "Scope must be between 0 and 1",
 		"Halber Tag ist nur für einen einzelnen Tag möglich": "Half day is only possible for a single day",
-		"Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)": "Day %1$s cannot be removed (month %2$02d/%3$d is approved)",
 		"Gültig-ab darf frühestens der 1. des aktuellen Monats sein": "Valid-from must be no earlier than the 1st of the current month",
 		"Ein Profil mit diesem Gültig-ab Datum existiert bereits": "A profile with this valid-from date already exists",
 		"Maximale tägliche Arbeitszeit ist %s Stunden (siehe Einstellungen)": "Maximum daily working time is %s hours (see settings)",
@@ -566,7 +565,9 @@
 		"Freizeitausgleich reduziert die Überstunden automatisch.": "Compensatory leave automatically reduces overtime.",
 		"Freizeitausgleich genommen": "Compensatory time taken",
 		"Hinweis: Der Zeitraum umfasst ca. {requested} Werktage (Resturlaub: {available}). Abgezogen werden nur deine Arbeitstage laut Arbeitszeitmodell – bei Teilzeit also weniger.": "Note: the period spans approx. {requested} working days (remaining: {available}). Only your working days according to your work schedule are deducted – fewer for part-time.",
-		"Hinweis: ca. {requested} Werktage im Zeitraum (Resturlaub: {available}). Abgezogen werden nur Arbeitstage laut Arbeitszeitmodell.": "Note: approx. {requested} working days in the period (remaining: {available}). Only working days according to the work schedule are deducted."
+		"Hinweis: ca. {requested} Werktage im Zeitraum (Resturlaub: {available}). Abgezogen werden nur Arbeitstage laut Arbeitszeitmodell.": "Note: approx. {requested} working days in the period (remaining: {available}). Only working days according to the work schedule are deducted.",
+		"Dieser Zeitraum ist abgeschlossen. Bitte wende dich an HR.": "This period is closed. Please contact HR.",
+		"Begründung erforderlich (mindestens 10 Zeichen).": "A reason is required (at least 10 characters)."
 	},
 	"pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/lib/Controller/AbsenceController.php
+++ b/lib/Controller/AbsenceController.php
@@ -90,7 +90,8 @@ class AbsenceController extends BaseController {
         string $startDate = '',
         string $endDate = '',
         ?string $note = null,
-        float $scope = 1.0
+        float $scope = 1.0,
+        ?string $reason = null
     ): JSONResponse {
         if ($authError = $this->requireAuth()) {
             return $authError;
@@ -109,6 +110,9 @@ class AbsenceController extends BaseController {
             return $this->successResponse(['error' => 'Scope must be between 0 and 1'], 400);
         }
 
+        // Only HR/Admin may correct closed months (with a mandatory reason).
+        $allowLockedOverride = $this->permissionService->canManageEmployees($this->userId);
+
         try {
             // Get employee's federal state
             $employee = $this->employeeService->find($employeeId);
@@ -122,7 +126,9 @@ class AbsenceController extends BaseController {
                 $note,
                 $federalState,
                 $this->userId,
-                $scope
+                $scope,
+                $reason,
+                $allowLockedOverride
             );
 
             return $this->createdResponse($absence);
@@ -138,7 +144,8 @@ class AbsenceController extends BaseController {
         string $startDate,
         string $endDate,
         ?string $note = null,
-        float $scope = 1.0
+        float $scope = 1.0,
+        ?string $reason = null
     ): JSONResponse {
         if ($authError = $this->requireAuth()) {
             return $authError;
@@ -148,6 +155,9 @@ class AbsenceController extends BaseController {
         if ($scope < 0 || $scope > 1) {
             return $this->successResponse(['error' => 'Scope must be between 0 and 1'], 400);
         }
+
+        // Only HR/Admin may correct closed months (with a mandatory reason).
+        $allowLockedOverride = $this->permissionService->canManageEmployees($this->userId);
 
         try {
             $absence = $this->absenceService->find($id);
@@ -168,7 +178,9 @@ class AbsenceController extends BaseController {
                 $note,
                 $federalState,
                 $this->userId,
-                $scope
+                $scope,
+                $reason,
+                $allowLockedOverride
             );
 
             return $this->successResponse($absence);

--- a/lib/Controller/TimeEntryController.php
+++ b/lib/Controller/TimeEntryController.php
@@ -85,7 +85,8 @@ class TimeEntryController extends BaseController {
         string $endTime = '',
         int $breakMinutes = 0,
         ?int $projectId = null,
-        ?string $description = null
+        ?string $description = null,
+        ?string $reason = null
     ): JSONResponse {
         if ($authError = $this->requireAuth()) {
             return $authError;
@@ -99,6 +100,9 @@ class TimeEntryController extends BaseController {
             return $this->forbiddenResponse();
         }
 
+        // Only HR/Admin may correct closed months (with a mandatory reason).
+        $allowLockedOverride = $this->permissionService->canManageEmployees($this->userId);
+
         try {
             $entry = $this->timeEntryService->create(
                 $employeeId,
@@ -108,7 +112,9 @@ class TimeEntryController extends BaseController {
                 $breakMinutes,
                 $projectId,
                 $description,
-                $this->userId
+                $this->userId,
+                $reason,
+                $allowLockedOverride
             );
 
             return $this->createdResponse($entry);
@@ -125,11 +131,15 @@ class TimeEntryController extends BaseController {
         string $endTime,
         int $breakMinutes,
         ?int $projectId = null,
-        ?string $description = null
+        ?string $description = null,
+        ?string $reason = null
     ): JSONResponse {
         if ($authError = $this->requireAuth()) {
             return $authError;
         }
+
+        // Only HR/Admin may correct closed months (with a mandatory reason).
+        $allowLockedOverride = $this->permissionService->canManageEmployees($this->userId);
 
         try {
             $entry = $this->timeEntryService->find($id);
@@ -146,7 +156,9 @@ class TimeEntryController extends BaseController {
                 $breakMinutes,
                 $projectId,
                 $description,
-                $this->userId
+                $this->userId,
+                $reason,
+                $allowLockedOverride
             );
 
             return $this->successResponse($entry);

--- a/lib/Service/AbsenceService.php
+++ b/lib/Service/AbsenceService.php
@@ -89,7 +89,9 @@ class AbsenceService {
         ?string $note = null,
         string $federalState = 'BY',
         string $currentUserId = '',
-        float $scope = 1.0
+        float $scope = 1.0,
+        ?string $reason = null,
+        bool $allowLockedOverride = false
     ): Absence {
         $startDateObj = new DateTime($startDate);
         $endDateObj = new DateTime($endDate);
@@ -99,6 +101,10 @@ class AbsenceService {
         if (!empty($errors)) {
             throw new ValidationException($errors);
         }
+
+        // Closed-month rules (#148): block employees, require a reason for HR corrections.
+        $lockedMonths = $this->timeEntryService->lockedMonthsInRange($employeeId, $startDateObj, $endDateObj);
+        $effectiveReason = $this->timeEntryService->requireReasonForLockedMonths($lockedMonths, $allowLockedOverride, $reason);
 
         // Calculate working days and apply scope (schedule-aware)
         $workingDays = $this->calculateWorkingDays($startDateObj, $endDateObj, $federalState, $employeeId);
@@ -132,9 +138,20 @@ class AbsenceService {
 
         $absence = $this->absenceMapper->insert($absence);
 
-        // Audit log
+        // Audit log (record the HR correction reason when present)
         if ($currentUserId) {
-            $this->auditLogService->logCreate($currentUserId, 'absence', $absence->getId(), $absence->jsonSerialize());
+            $newValues = $absence->jsonSerialize();
+            if ($effectiveReason !== null) {
+                $newValues['reason'] = $effectiveReason;
+            }
+            $this->auditLogService->logCreate($currentUserId, 'absence', $absence->getId(), $newValues);
+        }
+
+        // HR correction in a closed month: reopen the affected time-entry months.
+        if ($effectiveReason !== null) {
+            foreach ($lockedMonths as [$lockedYear, $lockedMonth]) {
+                $this->timeEntryService->reopenMonth($employeeId, $lockedYear, $lockedMonth, $effectiveReason, $currentUserId);
+            }
         }
 
         try {
@@ -163,10 +180,14 @@ class AbsenceService {
         ?string $note = null,
         string $federalState = 'BY',
         string $currentUserId = '',
-        float $scope = 1.0
+        float $scope = 1.0,
+        ?string $reason = null,
+        bool $allowLockedOverride = false
     ): Absence {
         $absence = $this->find($id);
         $oldValues = $absence->jsonSerialize();
+        $oldStart = clone $absence->getStartDate();
+        $oldEnd = clone $absence->getEndDate();
 
         // Cannot edit cancelled absences
         if ($absence->getStatus() === Absence::STATUS_CANCELLED) {
@@ -178,18 +199,17 @@ class AbsenceService {
 
         // Validate basic rules
         $errors = $this->validate($absence->getEmployeeId(), $type, $startDateObj, $endDateObj, $id, $scope);
-
-        // Validate modification if this is an approved absence being edited
-        if ($absence->getStatus() === Absence::STATUS_APPROVED) {
-            $modificationErrors = $this->validateModification($absence, $startDateObj, $endDateObj);
-            if (!empty($modificationErrors)) {
-                $errors['modification'] = $modificationErrors;
-            }
-        }
-
         if (!empty($errors)) {
             throw new ValidationException($errors);
         }
+
+        // Closed-month rules (#148): employees are blocked from any change that
+        // touches a closed month (old or new range); HR corrections require a
+        // reason and reopen the affected months.
+        $rangeStart = min($oldStart, $startDateObj);
+        $rangeEnd = max($oldEnd, $endDateObj);
+        $lockedMonths = $this->timeEntryService->lockedMonthsInRange($absence->getEmployeeId(), $rangeStart, $rangeEnd);
+        $effectiveReason = $this->timeEntryService->requireReasonForLockedMonths($lockedMonths, $allowLockedOverride, $reason);
 
         // Calculate working days and apply scope (schedule-aware)
         $workingDays = $this->calculateWorkingDays($startDateObj, $endDateObj, $federalState, $absence->getEmployeeId());
@@ -223,9 +243,20 @@ class AbsenceService {
 
         $absence = $this->absenceMapper->update($absence);
 
-        // Audit log
+        // Audit log (record the HR correction reason when present)
         if ($currentUserId) {
-            $this->auditLogService->logUpdate($currentUserId, 'absence', $absence->getId(), $oldValues, $absence->jsonSerialize());
+            $newValues = $absence->jsonSerialize();
+            if ($effectiveReason !== null) {
+                $newValues['reason'] = $effectiveReason;
+            }
+            $this->auditLogService->logUpdate($currentUserId, 'absence', $absence->getId(), $oldValues, $newValues);
+        }
+
+        // HR correction in a closed month: reopen the affected time-entry months.
+        if ($effectiveReason !== null) {
+            foreach ($lockedMonths as [$lockedYear, $lockedMonth]) {
+                $this->timeEntryService->reopenMonth($absence->getEmployeeId(), $lockedYear, $lockedMonth, $effectiveReason, $currentUserId);
+            }
         }
 
         return $absence;
@@ -467,48 +498,6 @@ class AbsenceService {
     }
 
     /**
-     * Validate that no days from approved months are being removed
-     *
-     * @return string[] Error messages
-     */
-    private function validateModification(Absence $absence, DateTime $newStart, DateTime $newEnd): array {
-        $errors = [];
-        $today = new DateTime('today');
-
-        // Get all days from original range
-        $originalDays = $this->getDaysInRange($absence->getStartDate(), $absence->getEndDate());
-        $newDays = $this->getDaysInRange($newStart, $newEnd);
-
-        // Convert new days to string array for comparison
-        $newDayStrings = array_map(fn(DateTime $d) => $d->format('Y-m-d'), $newDays);
-
-        // Find days being removed
-        foreach ($originalDays as $day) {
-            $dayString = $day->format('Y-m-d');
-            if (!in_array($dayString, $newDayStrings)) {
-                // Day is being removed - check if allowed
-                if ($day < $today) {
-                    // Day in past - check if month is approved
-                    $year = (int)$day->format('Y');
-                    $month = (int)$day->format('n');
-                    if ($this->timeEntryService->isMonthApproved($absence->getEmployeeId(), $year, $month)) {
-                        $errors[] = $this->l->t(
-                            'Tag %1$s kann nicht entfernt werden (Monat %2$02d/%3$d ist genehmigt)',
-                            [
-                                $day->format('d.m.Y'),
-                                $month,
-                                $year,
-                            ]
-                        );
-                    }
-                }
-            }
-        }
-
-        return $errors;
-    }
-
-    /**
      * Get absence overview for all visible employees in a given month.
      *
      * @return array[] Array of { employeeId, employeeName, absences }
@@ -596,20 +585,5 @@ class AbsenceService {
 
         // 'all' — visible to everyone
         return true;
-    }
-
-    /**
-     * Get all days in a date range
-     *
-     * @return DateTime[]
-     */
-    private function getDaysInRange(DateTime $start, DateTime $end): array {
-        $days = [];
-        $current = clone $start;
-        while ($current <= $end) {
-            $days[] = clone $current;
-            $current->modify('+1 day');
-        }
-        return $days;
     }
 }

--- a/lib/Service/TimeEntryService.php
+++ b/lib/Service/TimeEntryService.php
@@ -98,7 +98,9 @@ class TimeEntryService {
         int $breakMinutes,
         ?int $projectId = null,
         ?string $description = null,
-        string $currentUserId = ''
+        string $currentUserId = '',
+        ?string $reason = null,
+        bool $allowLockedOverride = false
     ): TimeEntry {
         $dateObj = new DateTime($date);
         $startTimeObj = DateTime::createFromFormat('H:i', $startTime) ?: null;
@@ -119,6 +121,10 @@ class TimeEntryService {
             throw new ValidationException($errors);
         }
 
+        // Closed-month rules (#148): block employees, require a reason for HR corrections.
+        $lockedMonths = $this->lockedMonthsInRange($employeeId, $dateObj, $dateObj);
+        $effectiveReason = $this->requireReasonForLockedMonths($lockedMonths, $allowLockedOverride, $reason);
+
         // Calculate work minutes
         $workMinutes = $this->calculateWorkMinutes($startTimeObj, $endTimeObj, $breakMinutes);
 
@@ -137,9 +143,18 @@ class TimeEntryService {
 
         $entry = $this->timeEntryMapper->insert($entry);
 
-        // Audit log
+        // Audit log (record the HR correction reason when present)
         if ($currentUserId) {
-            $this->auditLogService->logCreate($currentUserId, 'time_entry', $entry->getId(), $entry->jsonSerialize());
+            $newValues = $entry->jsonSerialize();
+            if ($effectiveReason !== null) {
+                $newValues['reason'] = $effectiveReason;
+            }
+            $this->auditLogService->logCreate($currentUserId, 'time_entry', $entry->getId(), $newValues);
+        }
+
+        // HR correction in a closed month: reopen the affected months for re-approval.
+        if ($effectiveReason !== null) {
+            $this->reopenLockedMonths($employeeId, $lockedMonths, $effectiveReason, $currentUserId);
         }
 
         return $entry;
@@ -157,10 +172,13 @@ class TimeEntryService {
         int $breakMinutes,
         ?int $projectId = null,
         ?string $description = null,
-        string $currentUserId = ''
+        string $currentUserId = '',
+        ?string $reason = null,
+        bool $allowLockedOverride = false
     ): TimeEntry {
         $entry = $this->find($id);
         $oldValues = $entry->jsonSerialize();
+        $oldDate = clone $entry->getDate();
 
         $dateObj = new DateTime($date);
         $startTimeObj = DateTime::createFromFormat('H:i', $startTime) ?: null;
@@ -181,14 +199,22 @@ class TimeEntryService {
             throw new ValidationException($errors);
         }
 
-        // Cannot edit approved entries
-        if ($entry->getStatus() === TimeEntry::STATUS_APPROVED) {
-            throw ValidationException::fromSingleError('status', 'Cannot edit approved time entries');
-        }
+        // Closed-month rules (#148): block employees, require a reason for HR
+        // corrections. Cover both the old and the new date (a move can leave a
+        // closed month).
+        $rangeStart = $oldDate <= $dateObj ? $oldDate : $dateObj;
+        $rangeEnd = $oldDate <= $dateObj ? $dateObj : $oldDate;
+        $lockedMonths = $this->lockedMonthsInRange($entry->getEmployeeId(), $rangeStart, $rangeEnd);
+        $effectiveReason = $this->requireReasonForLockedMonths($lockedMonths, $allowLockedOverride, $reason);
 
-        // Cannot edit submitted entries (awaiting approval; HR uses reopen/reject)
-        if ($entry->getStatus() === TimeEntry::STATUS_SUBMITTED) {
-            throw ValidationException::fromSingleError('status', 'Cannot edit submitted time entries');
+        // Employees cannot edit approved/submitted entries; an HR correction may.
+        if (!$allowLockedOverride) {
+            if ($entry->getStatus() === TimeEntry::STATUS_APPROVED) {
+                throw ValidationException::fromSingleError('status', 'Cannot edit approved time entries');
+            }
+            if ($entry->getStatus() === TimeEntry::STATUS_SUBMITTED) {
+                throw ValidationException::fromSingleError('status', 'Cannot edit submitted time entries');
+            }
         }
 
         // Calculate work minutes
@@ -203,16 +229,33 @@ class TimeEntryService {
         $entry->setDescription($description);
         $entry->setUpdatedAt(new DateTime());
 
-        // Reset to draft if was rejected
-        if ($entry->getStatus() === TimeEntry::STATUS_REJECTED) {
+        if ($effectiveReason !== null) {
+            // HR correction in a closed month: the entry returns to draft and the
+            // month is reopened for re-approval.
+            $entry->setStatus(TimeEntry::STATUS_DRAFT);
+            $entry->setApprovedAt(null);
+            $entry->setApprovedBy(null);
+            $entry->setSubmittedAt(null);
+            $entry->setSubmittedBy(null);
+        } elseif ($entry->getStatus() === TimeEntry::STATUS_REJECTED) {
+            // Reset to draft if was rejected
             $entry->setStatus(TimeEntry::STATUS_DRAFT);
         }
 
         $entry = $this->timeEntryMapper->update($entry);
 
-        // Audit log
+        // Audit log (record the HR correction reason when present)
         if ($currentUserId) {
-            $this->auditLogService->logUpdate($currentUserId, 'time_entry', $entry->getId(), $oldValues, $entry->jsonSerialize());
+            $newValues = $entry->jsonSerialize();
+            if ($effectiveReason !== null) {
+                $newValues['reason'] = $effectiveReason;
+            }
+            $this->auditLogService->logUpdate($currentUserId, 'time_entry', $entry->getId(), $oldValues, $newValues);
+        }
+
+        // Reopen the affected closed months for re-approval.
+        if ($effectiveReason !== null) {
+            $this->reopenLockedMonths($entry->getEmployeeId(), $lockedMonths, $effectiveReason, $currentUserId);
         }
 
         return $entry;
@@ -577,6 +620,85 @@ class TimeEntryService {
         $summary = $this->timeEntryMapper->getMonthlyStatusSummary($employeeId, $year, $month);
         $total = $summary['draft'] + $summary['submitted'] + $summary['approved'] + $summary['rejected'];
         return $total > 0 && $summary['approved'] === $total;
+    }
+
+    /**
+     * Whether a month is locked for employee self-service (#148): a month is
+     * locked when it is fully approved, or when it lies in a past calendar year
+     * (regardless of approval status). HR/Admin can still correct it via the
+     * HR correction flow (reason + month reopening).
+     */
+    public function isMonthLocked(int $employeeId, int $year, int $month): bool {
+        $currentYear = (int)(new DateTime())->format('Y');
+        if ($year < $currentYear) {
+            return true;
+        }
+        return $this->isMonthApproved($employeeId, $year, $month);
+    }
+
+    /**
+     * The locked months that a date range touches.
+     *
+     * @return array<array{0: int, 1: int}> list of [year, month] pairs
+     */
+    public function lockedMonthsInRange(int $employeeId, DateTime $start, DateTime $end): array {
+        $locked = [];
+        $cursor = new DateTime($start->format('Y-m-01'));
+        $last = new DateTime($end->format('Y-m-01'));
+        while ($cursor <= $last) {
+            $year = (int)$cursor->format('Y');
+            $month = (int)$cursor->format('n');
+            if ($this->isMonthLocked($employeeId, $year, $month)) {
+                $locked[] = [$year, $month];
+            }
+            $cursor->modify('+1 month');
+        }
+        return $locked;
+    }
+
+    /**
+     * Enforce the closed-month rules for a create/update (#148), shared by the
+     * time-entry and absence services.
+     *
+     * - No locked month touched: returns null (normal save).
+     * - Locked month touched without override: blocks (employee self-service).
+     * - Locked month touched with override (HR/Admin): requires a reason of at
+     *   least 10 characters and returns it (the caller records it in the audit
+     *   log and reopens the affected months).
+     *
+     * @param array<array{0: int, 1: int}> $lockedMonths
+     * @throws ValidationException
+     */
+    public function requireReasonForLockedMonths(array $lockedMonths, bool $allowOverride, ?string $reason): ?string {
+        if (empty($lockedMonths)) {
+            return null;
+        }
+        if (!$allowOverride) {
+            throw ValidationException::fromSingleError(
+                'period',
+                $this->l->t('Dieser Zeitraum ist abgeschlossen. Bitte wende dich an HR.')
+            );
+        }
+        $reason = trim((string)$reason);
+        if (mb_strlen($reason) < 10) {
+            throw ValidationException::fromSingleError(
+                'reason',
+                $this->l->t('Begründung erforderlich (mindestens 10 Zeichen).')
+            );
+        }
+        return $reason;
+    }
+
+    /**
+     * Reopen the given (closed) months after an HR correction: their approved
+     * entries go back to draft and the employee is notified.
+     *
+     * @param array<array{0: int, 1: int}> $lockedMonths
+     */
+    private function reopenLockedMonths(int $employeeId, array $lockedMonths, string $reason, string $currentUserId): void {
+        foreach ($lockedMonths as [$year, $month]) {
+            $this->reopenMonth($employeeId, $year, $month, $reason, $currentUserId);
+        }
     }
 
     /**

--- a/tests/Unit/Service/TimeEntryServiceTest.php
+++ b/tests/Unit/Service/TimeEntryServiceTest.php
@@ -198,4 +198,56 @@ class TimeEntryServiceTest extends TestCase {
         $this->assertEquals(160.0, $stats['totalWorkHours']);
         $this->assertEquals(22, $stats['entryCount']);
     }
+
+    // --- #148: closed-month locking + HR correction override ---
+
+    public function testIsMonthLockedPastYearIsAlwaysLocked(): void {
+        $pastYear = (int)(new DateTime())->format('Y') - 1;
+        // A past calendar year is locked regardless of approval status.
+        $this->assertTrue($this->service->isMonthLocked(1, $pastYear, 6));
+    }
+
+    public function testIsMonthLockedCurrentYearApprovedIsLocked(): void {
+        $year = (int)(new DateTime())->format('Y');
+        $this->timeEntryMapper->method('getMonthlyStatusSummary')
+            ->willReturn(['draft' => 0, 'submitted' => 0, 'approved' => 3, 'rejected' => 0]);
+        $this->assertTrue($this->service->isMonthLocked(1, $year, 3));
+    }
+
+    public function testIsMonthLockedCurrentYearNotApprovedIsOpen(): void {
+        $year = (int)(new DateTime())->format('Y');
+        $this->timeEntryMapper->method('getMonthlyStatusSummary')
+            ->willReturn(['draft' => 1, 'submitted' => 1, 'approved' => 2, 'rejected' => 0]);
+        $this->assertFalse($this->service->isMonthLocked(1, $year, 3));
+    }
+
+    public function testRequireReasonReturnsNullWhenNoLockedMonths(): void {
+        $this->assertNull($this->service->requireReasonForLockedMonths([], true, null));
+        $this->assertNull($this->service->requireReasonForLockedMonths([], false, 'whatever'));
+    }
+
+    public function testRequireReasonBlocksEmployeeOnLockedMonth(): void {
+        $this->expectException(ValidationException::class);
+        $this->service->requireReasonForLockedMonths([[2025, 5]], false, null);
+    }
+
+    public function testRequireReasonRejectsTooShortReasonForHrOverride(): void {
+        $this->expectException(ValidationException::class);
+        $this->service->requireReasonForLockedMonths([[2025, 5]], true, 'zu kurz'); // 7 chars
+    }
+
+    public function testRequireReasonReturnsTrimmedReasonForHrOverride(): void {
+        $reason = $this->service->requireReasonForLockedMonths([[2025, 5]], true, '  Stempelfehler korrigiert  ');
+        $this->assertSame('Stempelfehler korrigiert', $reason);
+    }
+
+    public function testLockedMonthsInRangeListsEachLockedMonth(): void {
+        $pastYear = (int)(new DateTime())->format('Y') - 1;
+        $start = new DateTime("$pastYear-01-15");
+        $end = new DateTime("$pastYear-03-10");
+        $this->assertSame(
+            [[$pastYear, 1], [$pastYear, 2], [$pastYear, 3]],
+            $this->service->lockedMonthsInRange(1, $start, $end)
+        );
+    }
 }


### PR DESCRIPTION
## #148 — Teil 1: Backend-Fundament

Setzt die Sicherheits- und Logikschicht des HR-Korrekturworkflows um. Der Frontend-Teil (Korrektur-Modus + „Korrigieren"-Einstieg + Begründungs-Dialog, gemäß abgestimmtem Mockup) folgt in einem eigenen PR.

### Was dieser PR macht
- **Sperr-Erkennung** (`TimeEntryService::isMonthLocked`): Monat gilt als gesperrt, wenn er voll genehmigt ist **oder** in einem vergangenen Kalenderjahr liegt. `lockedMonthsInRange` für Datumsbereiche (Abwesenheiten über mehrere Monate).
- **Mitarbeitersperre**: `create`/`update` von Abwesenheiten **und** Zeiteinträgen blockieren in gesperrten Monaten mit klarer Meldung „Dieser Zeitraum ist abgeschlossen. Bitte wende dich an HR." (Backend = Sicherheit; Frontend-Guard kommt im 2. PR).
- **HR-Override**: `canManageEmployees` (Admin/HR) darf korrigieren, dann ist eine **Pflichtbegründung (min. 10 Zeichen)** nötig. Begründung landet im **Audit-Log** (`newValues['reason']`) — keine Migration.
- **Monats-Reöffnung**: jede Korrektur in einem gesperrten Monat ruft `reopenMonth` für die betroffenen Monate (genehmigte Einträge → Entwurf, Mitarbeiter-Notification) → erneute Genehmigung erforderlich.
- **Aufräumen**: ungenutztes `validateModification`/`getDaysInRange` entfernt (durch die strengere Monatssperre ersetzt), verwaisten l10n-String entfernt, neue Strings de(Quelle)+en.

### Tests
8 neue PHPUnit-Fälle (`TimeEntryServiceTest`): `isMonthLocked` (vergangenes Jahr / genehmigt / offen), `requireReasonForLockedMonths` (kein Lock / Mitarbeiter blockiert / Reason zu kurz / Reason getrimmt), `lockedMonthsInRange`. Lokal grün.

Hinweis: Eine vorbestehende, unabhängige Test-Failure (`testInvalidTimeFormat`, Pausen-Logik) existiert bereits auf `develop` und ist nicht Teil dieses PRs.

Refs #148
