### PR TITLE
fix(#148): Reopen-Notification wieder zustellbar + Begründung im Betreff

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -519,6 +519,7 @@ OC.L10N.register(
     "Deine Zeiteinträge für %s wurden genehmigt" : "Deine Zeiteinträge für %s wurden genehmigt",
     "Deine Zeiteinträge für %s wurden abgelehnt" : "Deine Zeiteinträge für %s wurden abgelehnt",
     "Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen." : "Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen.",
+    "Die Genehmigung deiner Zeiteinträge für %1$s wurde zurückgenommen (Grund: %2$s). Bitte erneut einreichen." : "Die Genehmigung deiner Zeiteinträge für %1$s wurde zurückgenommen (Grund: %2$s). Bitte erneut einreichen.",
     "Zukünftige Einträge sind nicht erlaubt" : "Zukünftige Einträge sind nicht erlaubt",
     "Ungültiges Zeitformat" : "Ungültiges Zeitformat",
     "Maximale tägliche Arbeitszeit (%s Std.) überschritten" : "Maximale tägliche Arbeitszeit (%s Std.) überschritten",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -518,6 +518,7 @@
 		"Deine Zeiteinträge für %s wurden genehmigt": "Deine Zeiteinträge für %s wurden genehmigt",
 		"Deine Zeiteinträge für %s wurden abgelehnt": "Deine Zeiteinträge für %s wurden abgelehnt",
 		"Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen.": "Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen.",
+		"Die Genehmigung deiner Zeiteinträge für %1$s wurde zurückgenommen (Grund: %2$s). Bitte erneut einreichen.": "Die Genehmigung deiner Zeiteinträge für %1$s wurde zurückgenommen (Grund: %2$s). Bitte erneut einreichen.",
 		"Zukünftige Einträge sind nicht erlaubt": "Zukünftige Einträge sind nicht erlaubt",
 		"Ungültiges Zeitformat": "Ungültiges Zeitformat",
 		"Maximale tägliche Arbeitszeit (%s Std.) überschritten": "Maximale tägliche Arbeitszeit (%s Std.) überschritten",

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -580,6 +580,6 @@ OC.L10N.register(
     "Begründung (mindestens 10 Zeichen)" : "Reason (at least 10 characters)",
     "z. B. Stempelfehler nach Rücksprache mit der Mitarbeiterin korrigiert" : "e.g. corrected a clock-in error after consulting the employee",
     "Korrektur speichern" : "Save correction",
-    "Begründung der Korrektur: %s" : "Reason for the correction: %s"
+    "Die Genehmigung deiner Zeiteinträge für %1$s wurde zurückgenommen (Grund: %2$s). Bitte erneut einreichen." : "The approval of your time entries for %1$s was withdrawn (reason: %2$s). Please resubmit."
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -579,7 +579,7 @@
 		"Begründung (mindestens 10 Zeichen)": "Reason (at least 10 characters)",
 		"z. B. Stempelfehler nach Rücksprache mit der Mitarbeiterin korrigiert": "e.g. corrected a clock-in error after consulting the employee",
 		"Korrektur speichern": "Save correction",
-		"Begründung der Korrektur: %s": "Reason for the correction: %s"
+		"Die Genehmigung deiner Zeiteinträge für %1$s wurde zurückgenommen (Grund: %2$s). Bitte erneut einreichen.": "The approval of your time entries for %1$s was withdrawn (reason: %2$s). Please resubmit."
 	},
 	"pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -140,15 +140,19 @@ class Notifier implements INotifier {
 				break;
 
 			case 'time_entries_reopened':
-				$notification->setParsedSubject(
-					$l->t(
-						'Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen.',
-						[$params['monthYear']]
-					)
-				);
 				if (!empty($params['reason'])) {
-					$notification->setParsedMessage(
-						$l->t('Begründung der Korrektur: %s', [$params['reason']])
+					$notification->setParsedSubject(
+						$l->t(
+							'Die Genehmigung deiner Zeiteinträge für %1$s wurde zurückgenommen (Grund: %2$s). Bitte erneut einreichen.',
+							[$params['monthYear'], $params['reason']]
+						)
+					);
+				} else {
+					$notification->setParsedSubject(
+						$l->t(
+							'Die Genehmigung deiner Zeiteinträge für %s wurde zurückgenommen. Bitte erneut einreichen.',
+							[$params['monthYear']]
+						)
 					);
 				}
 				break;


### PR DESCRIPTION
Folgefix zu #290: Der separate `setParsedMessage`-Body ließ NCs Notifier die `time_entries_reopened`-Notification nicht parsen → NC verwarf sie (Mitarbeiter bekam keine Benachrichtigung). Begründung jetzt im geparsten Betreff. Per Playwright (echter HTTP-Pfad) verifiziert: Notification persistiert + enthält Begründung. Verwaisten l10n-String entfernt.

Refs #148