### PR TITLE
perf(report): Projekt-Listen im PDF-Export nur einmal laden + Tests (#311)

### DIFF
--- a/lib/Controller/ReportController.php
+++ b/lib/Controller/ReportController.php
@@ -269,8 +269,8 @@ class ReportController extends BaseController {
         try {
             $pIds = $this->parseIds($projectIds);
             $eIds = $this->parseIds($employeeIds);
-            [, , $label, $entries, $totals] = $this->collectProjectEntries($year, $month, $period, $billableOnly, $pIds, $eIds);
-            $filter = $this->selectionLabels($pIds, $eIds);
+            [, , $label, $entries, $totals, $projects, $employees] = $this->collectProjectEntries($year, $month, $period, $billableOnly, $pIds, $eIds);
+            $filter = $this->selectionLabels($pIds, $eIds, $projects, $employees);
             $pdf = $mode === 'agg'
                 ? $this->pdfService->generateProjectAggregate($label, $this->aggregateByEmployee($entries), $totals['totalMinutes'], $filter)
                 : $this->pdfService->generateProjectEvaluation($label, $entries, $totals, $filter);
@@ -286,7 +286,7 @@ class ReportController extends BaseController {
      *
      * @param int[] $projectIds optional filter (empty = all)
      * @param int[] $employeeIds optional filter (empty = all)
-     * @return array{0: DateTime, 1: DateTime, 2: string, 3: array, 4: array{totalMinutes: int, billableMinutes: int}}
+     * @return array{0: DateTime, 1: DateTime, 2: string, 3: array, 4: array{totalMinutes: int, billableMinutes: int}, 5: array<int, \OCA\WorkTime\Db\Project>, 6: array<int, \OCA\WorkTime\Db\Employee>}
      */
     private function collectProjectEntries(int $year, int $month, string $period, bool $billableOnly, array $projectIds = [], array $employeeIds = []): array {
         [$start, $end, $label] = $this->resolvePeriod($year, $month, $period);
@@ -341,7 +341,7 @@ class ReportController extends BaseController {
             }
         }
 
-        return [$start, $end, $label, $entries, ['totalMinutes' => $totalMinutes, 'billableMinutes' => $billableMinutes]];
+        return [$start, $end, $label, $entries, ['totalMinutes' => $totalMinutes, 'billableMinutes' => $billableMinutes], $projects, $employees];
     }
 
     /**
@@ -378,38 +378,39 @@ class ReportController extends BaseController {
 
     /**
      * Human-readable labels for the current selection, for the export header.
-     * Empty id list => "Alle".
+     * Empty id list => "Alle". The project/employee maps are reused from
+     * collectProjectEntries() to avoid a second findAll() round-trip (#311).
      *
      * @param int[] $projectIds
      * @param int[] $employeeIds
+     * @param array<int, \OCA\WorkTime\Db\Project> $projects id-keyed map
+     * @param array<int, \OCA\WorkTime\Db\Employee> $employees id-keyed map
      * @return array{projects: string, employees: string}
      */
-    private function selectionLabels(array $projectIds, array $employeeIds): array {
-        $projects = 'Alle';
+    private function selectionLabels(array $projectIds, array $employeeIds, array $projects, array $employees): array {
+        $projectsLabel = 'Alle';
         if (!empty($projectIds)) {
-            $set = array_flip($projectIds);
             $names = [];
-            foreach ($this->projectService->findAll() as $p) {
-                if (isset($set[$p->getId()])) {
-                    $names[] = $p->getName();
+            foreach ($projectIds as $id) {
+                if (isset($projects[$id])) {
+                    $names[] = $projects[$id]->getName();
                 }
             }
-            $projects = implode(', ', $names);
+            $projectsLabel = implode(', ', $names);
         }
 
-        $employees = 'Alle';
+        $employeesLabel = 'Alle';
         if (!empty($employeeIds)) {
-            $set = array_flip($employeeIds);
             $names = [];
-            foreach ($this->employeeService->findAll() as $e) {
-                if (isset($set[$e->getId()])) {
-                    $names[] = $e->getFullName();
+            foreach ($employeeIds as $id) {
+                if (isset($employees[$id])) {
+                    $names[] = $employees[$id]->getFullName();
                 }
             }
-            $employees = implode(', ', $names);
+            $employeesLabel = implode(', ', $names);
         }
 
-        return ['projects' => $projects, 'employees' => $employees];
+        return ['projects' => $projectsLabel, 'employees' => $employeesLabel];
     }
 
     private function csvCell(string $value): string {

--- a/tests/Unit/Controller/ReportControllerTest.php
+++ b/tests/Unit/Controller/ReportControllerTest.php
@@ -6,8 +6,10 @@ namespace OCA\WorkTime\Tests\Unit\Controller;
 
 use OCA\WorkTime\Controller\ReportController;
 use OCA\WorkTime\Db\AbsenceMapper;
+use DateTime;
 use OCA\WorkTime\Db\Employee;
 use OCA\WorkTime\Db\Project;
+use OCA\WorkTime\Db\TimeEntry;
 use OCA\WorkTime\Db\TimeEntryMapper;
 use OCA\WorkTime\Service\AbsenceService;
 use OCA\WorkTime\Service\EmployeeService;
@@ -73,6 +75,17 @@ class ReportControllerTest extends TestCase {
         return $e;
     }
 
+    private function timeEntry(int $id, string $date, int $projectId, int $employeeId, int $minutes, string $desc = ''): TimeEntry {
+        $te = new TimeEntry();
+        $te->setId($id);
+        $te->setDate(new DateTime($date));
+        $te->setProjectId($projectId);
+        $te->setEmployeeId($employeeId);
+        $te->setWorkMinutes($minutes);
+        $te->setDescription($desc);
+        return $te;
+    }
+
     public function testProjectsAggregatesRowsAndTotals(): void {
         $this->projectService->method('findAll')->willReturn([
             $this->project(1, 'Intern', false),
@@ -133,5 +146,73 @@ class ReportControllerTest extends TestCase {
         );
 
         $this->assertSame(403, $controller->projects(2026, 6, 'month')->getStatus());
+    }
+
+    public function testProjectEntriesReturnsEnrichedBookings(): void {
+        $this->projectService->method('findAll')->willReturn([$this->project(2, 'Acme', true)]);
+        $this->employeeService->method('findAll')->willReturn([$this->employee(5, 'Test', 'User')]);
+        $this->timeEntryMapper->method('findByDateRange')->willReturn([
+            $this->timeEntry(10, '2026-06-15', 2, 5, 120, 'Arbeit'),
+        ]);
+
+        $data = $this->controller->projectEntries(2026, 6, 'month')->getData();
+
+        $this->assertCount(1, $data['entries']);
+        $this->assertSame(120, $data['totals']['totalMinutes']);
+        $entry = $data['entries'][0];
+        $this->assertSame('Acme', $entry['projectName']);
+        $this->assertSame('Test User', $entry['employeeName']);
+        $this->assertTrue($entry['isBillable']);
+    }
+
+    public function testProjectsCsvDetailContainsBookingRow(): void {
+        $this->projectService->method('findAll')->willReturn([$this->project(2, 'Acme', true)]);
+        $this->employeeService->method('findAll')->willReturn([$this->employee(5, 'Test', 'User')]);
+        $this->timeEntryMapper->method('findByDateRange')->willReturn([
+            $this->timeEntry(10, '2026-06-15', 2, 5, 120, 'Arbeit'),
+        ]);
+
+        $csv = $this->controller->projectsCsv(2026, 6, 'month', false, '', '', 'detail')->render();
+
+        $this->assertStringContainsString('Datum', $csv);   // header present
+        $this->assertStringContainsString('Acme', $csv);
+        $this->assertStringContainsString('15.06.2026', $csv);
+        $this->assertStringContainsString('2,00', $csv);     // 120 min as decimal hours
+    }
+
+    public function testProjectsCsvAggModeSumsMinutesPerEmployee(): void {
+        $this->projectService->method('findAll')->willReturn([$this->project(2, 'Acme', true)]);
+        $this->employeeService->method('findAll')->willReturn([$this->employee(5, 'Test', 'User')]);
+        $this->timeEntryMapper->method('findByDateRange')->willReturn([
+            $this->timeEntry(10, '2026-06-15', 2, 5, 120),
+            $this->timeEntry(11, '2026-06-16', 2, 5, 60),
+        ]);
+
+        $csv = $this->controller->projectsCsv(2026, 6, 'month', false, '', '', 'agg')->render();
+
+        $this->assertStringContainsString('Mitarbeiter', $csv); // aggregate header
+        $this->assertStringContainsString('Test User', $csv);
+        $this->assertStringContainsString('3,00', $csv);        // 120 + 60 = 180 min
+        $this->assertStringContainsString('100 %', $csv);       // sole employee = 100 %
+    }
+
+    /**
+     * Regression guard for #311: the PDF export must load the project and
+     * employee lists exactly once. The previous code loaded them again in
+     * selectionLabels() whenever a filter was set (4 queries instead of 2).
+     */
+    public function testProjectsPdfLoadsProjectsAndEmployeesOnce(): void {
+        $this->projectService->expects($this->once())->method('findAll')
+            ->willReturn([$this->project(2, 'Acme', true)]);
+        $this->employeeService->expects($this->once())->method('findAll')
+            ->willReturn([$this->employee(5, 'Test', 'User')]);
+        $this->timeEntryMapper->method('findByDateRange')->willReturn([
+            $this->timeEntry(10, '2026-06-15', 2, 5, 120),
+        ]);
+
+        // Filters set, so the old code would have re-queried in selectionLabels().
+        $response = $this->controller->projectsPdf(2026, 6, 'month', false, '2', '5', 'detail');
+
+        $this->assertSame(200, $response->getStatus());
     }
 }

--- a/tests/Unit/Service/ProjectServiceTest.php
+++ b/tests/Unit/Service/ProjectServiceTest.php
@@ -9,6 +9,7 @@ use OCA\WorkTime\Db\ProjectEmployeeMapper;
 use OCA\WorkTime\Db\ProjectMapper;
 use OCA\WorkTime\Service\AuditLogService;
 use OCA\WorkTime\Service\ProjectService;
+use OCA\WorkTime\Service\ValidationException;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -75,5 +76,52 @@ class ProjectServiceTest extends TestCase {
         $ids = array_map(static fn (Project $p) => $p->getId(), $result);
 
         $this->assertSame([1, 2], $ids);
+    }
+
+    public function testCreateRejectsEmptyName(): void {
+        // Validation must fail before any insert happens.
+        $this->projectMapper->expects($this->never())->method('insert');
+
+        try {
+            $this->service->create('   ');
+            $this->fail('Expected ValidationException for empty name');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('name', $e->getErrors());
+        }
+    }
+
+    public function testCreateRejectsDuplicateCode(): void {
+        $this->projectMapper->method('existsByCode')->with('DUP', null)->willReturn(true);
+        $this->projectMapper->expects($this->never())->method('insert');
+
+        try {
+            $this->service->create('Gültiger Name', 'DUP');
+            $this->fail('Expected ValidationException for duplicate code');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('code', $e->getErrors());
+        }
+    }
+
+    public function testCreateRejectsTooLongCode(): void {
+        $this->projectMapper->method('existsByCode')->willReturn(false);
+        $this->projectMapper->expects($this->never())->method('insert');
+
+        try {
+            $this->service->create('Gültiger Name', str_repeat('X', 51));
+            $this->fail('Expected ValidationException for code exceeding 50 chars');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('code', $e->getErrors());
+        }
+    }
+
+    public function testDeleteRemovesMembershipsAndProject(): void {
+        $project = $this->makeProject(7, true);
+        $this->projectMapper->method('find')->willReturn($project);
+
+        // Memberships must be cleared before the project row itself is deleted.
+        $this->projectEmployeeMapper->expects($this->once())->method('deleteForProject')->with(7);
+        $this->projectMapper->expects($this->once())->method('delete')->with($project);
+
+        $this->service->delete(7);
     }
 }

--- a/tests/Unit/Service/TimeEntryServiceTest.php
+++ b/tests/Unit/Service/TimeEntryServiceTest.php
@@ -316,4 +316,38 @@ class TimeEntryServiceTest extends TestCase {
         $this->expectException(ForbiddenException::class);
         $this->service->delete(99, 'admin', 'genug lange Begründung', true);
     }
+
+    /**
+     * Project assignment guard (#58): an employee who is not assigned to a
+     * restricted project must be rejected when booking on it. The guard runs
+     * after the basic time validation, so we use a valid past entry that clears
+     * all other checks (no future date, no overlap, no absence conflict).
+     */
+    public function testCreateRejectsBookingOnUnassignedProject(): void {
+        $projectService = $this->createMock(ProjectService::class);
+        $projectService->method('isProjectAllowedForEmployee')->willReturn(false);
+        $service = new TimeEntryService(
+            $this->timeEntryMapper,
+            $this->settingsMapper,
+            $this->employeeMapper,
+            $this->absenceMapper,
+            $this->auditLogService,
+            $this->notificationService,
+            $projectService,
+            $this->logger,
+            $this->l,
+        );
+        // No overlapping entries and no absence on that day.
+        $this->timeEntryMapper->method('findByEmployeeAndDate')->willReturn([]);
+        $this->absenceMapper->method('findByEmployeeAndDate')->willReturn([]);
+        // The booking must never be persisted when the guard rejects it.
+        $this->timeEntryMapper->expects($this->never())->method('insert');
+
+        try {
+            $service->create(5, '2020-01-06', '08:00', '14:00', 0, 7);
+            $this->fail('Expected ValidationException for unassigned project');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('projectId', $e->getErrors());
+        }
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,19 +8,23 @@ declare(strict_types=1);
  * Lädt die Nextcloud Autoloader und Test-Umgebung.
  */
 
-// Nextcloud Server Root (anpassen falls nötig)
-$ncRoot = getenv('NC_ROOT') ?: '/var/www/nextcloud';
+// Nextcloud Server Root (per NC_ROOT überschreibbar; Docker-Dev nutzt /var/www/html)
+$ncRoot = getenv('NC_ROOT') ?: '/var/www/html';
 
-// Autoloader laden
+// Nextcloud Server-Umgebung laden. Stellt die echten OCP-Klassen (Entity,
+// QBMapper, Http\Response …) bereit, die die Unit-Tests instanziieren.
 require_once $ncRoot . '/lib/base.php';
 
-// PHPUnit Compatibility
-if (!class_exists('\PHPUnit\Framework\TestCase')) {
-    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
-}
-
-// OCP Classes mocken für Unit Tests
-\OC::$loader->addValidRoot(__DIR__ . '/..');
-
-// App Namespace registrieren
-\OC_App::loadApp('worktime');
+// App-Namespace OCA\WorkTime autoloadbar machen (PSR-4 → lib/). Bewusst ohne
+// internes App-Loader-API, damit ausschliesslich OCP/PSR-4 verwendet wird.
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'OCA\\WorkTime\\';
+    if (!str_starts_with($class, $prefix)) {
+        return;
+    }
+    $relative = str_replace('\\', '/', substr($class, strlen($prefix)));
+    $path = __DIR__ . '/../lib/' . $relative . '.php';
+    if (is_file($path)) {
+        require_once $path;
+    }
+});


### PR DESCRIPTION
Adressiert die nicht-blockierenden Bot-Findings aus PR #309 (v0.11.0).

## 1. Performance

`projectsPdf()` lud die Projekt- und Mitarbeiterlisten **doppelt**: einmal in `collectProjectEntries()` und erneut in `selectionLabels()` → 4 statt 2 Queries pro PDF-Export, sobald ein Filter gesetzt war.

`collectProjectEntries()` gibt die geladenen, id-keyed Maps jetzt zurück; `selectionLabels()` nimmt sie als Parameter und ruft `findAll()` nicht mehr erneut auf.

## 2. Testlücken geschlossen

- **ReportControllerTest:** `projectEntries()`, `projectsCsv()` (detail + agg-Modus), und eine **Regression-Guard** die sicherstellt, dass `projectsPdf()` die Listen genau einmal lädt (`expects($this->once())`).
- **ProjectServiceTest:** `validate()` (Name-Pflicht, Duplikat-Code, Code-Längenlimit) und `delete()` (Memberships + Projekt-Row).
- **TimeEntryServiceTest:** Projekt-Zuordnungs-Guard (#58) — Buchung auf nicht zugewiesenem restricted Projekt wird abgewiesen.

## 3. Test-Bootstrap repariert

`tests/bootstrap.php` nutzte die in aktuellen NC-Versionen entfernte Legacy-API (`OC::$loader->addValidRoot`), wodurch die Suite gar nicht startete. Lädt jetzt `base.php` (echte OCP-Klassen) + einen PSR-4-Autoloader für `OCA\WorkTime` — ohne internes `OC_*`-API.

## Verifikation

Alle neuen Tests grün im NC-Dev-Container (PHP 8.4):
- ReportControllerTest + ProjectServiceTest: 15/15
- TimeEntryService #58-Guard: 1/1

Hinweis: Die übrige Suite hat vorbestehende, umgebungsbedingte Mock-Inkompatibilitäten (PHP 8.4 / NC-Dev), die nichts mit dieser Änderung zu tun haben.

Fixes #311