### PR TITLE
feat(pdf): lückenlose Tagesübersicht im Monatsbericht (#318)

### DIFF
--- a/lib/Service/PdfService.php
+++ b/lib/Service/PdfService.php
@@ -64,7 +64,7 @@ class PdfService {
         $this->addHeader($pdf, $employee, $year, $month);
 
         // Time entries table
-        $this->addTimeEntriesTable($pdf, $timeEntries, $holidays, $year, $month);
+        $this->addTimeEntriesTable($pdf, $timeEntries, $absences, $holidays, $year, $month);
 
         // Absences section
         if (!empty($absences)) {
@@ -337,28 +337,14 @@ class PdfService {
     /**
      * Add time entries table
      */
-    private function addTimeEntriesTable(TCPDF $pdf, array $timeEntries, array $holidays, int $year, int $month): void {
-        // Build holiday lookup
-        $holidayDates = [];
-        foreach ($holidays as $holiday) {
-            $holidayDates[$holiday->getDate()->format('Y-m-d')] = $holiday->getName();
-        }
-
+    private function addTimeEntriesTable(TCPDF $pdf, array $timeEntries, array $absences, array $holidays, int $year, int $month): void {
         // Project id -> name lookup (including inactive projects for historical entries).
         $projectNames = [];
         foreach ($this->projectMapper->findAll() as $project) {
             $projectNames[$project->getId()] = $project->getName();
         }
 
-        // Build entries by date
-        $entriesByDate = [];
-        foreach ($timeEntries as $entry) {
-            $date = $entry->getDate()->format('Y-m-d');
-            if (!isset($entriesByDate[$date])) {
-                $entriesByDate[$date] = [];
-            }
-            $entriesByDate[$date][] = $entry;
-        }
+        $rows = $this->buildDayRows($timeEntries, $absences, $holidays, $year, $month, $projectNames);
 
         // Table header
         $pdf->SetFont(self::FONT_FAMILY, 'B', self::FONT_SIZE_SMALL);
@@ -375,7 +361,69 @@ class PdfService {
 
         // Table body
         $pdf->SetFont(self::FONT_FAMILY, '', self::FONT_SIZE_SMALL);
+        foreach ($rows as $row) {
+            if ($row['fill']) {
+                $pdf->SetFillColor(245, 245, 245);
+            }
+            $this->renderTimeEntryRow(
+                $pdf, $row['date'], $row['day'], $row['start'], $row['end'],
+                $row['break'], $row['work'], $row['project'], $row['note'], $row['fill']
+            );
+        }
 
+        $pdf->Ln(5);
+    }
+
+    /**
+     * Build the ordered list of day rows for the monthly overview (#318).
+     *
+     * Every calendar day of the month produces at least one row so the overview
+     * is gap-free:
+     *  - days with bookings → one row per booking (plus a marker row for a
+     *    genuine half-day absence on the same day);
+     *  - full-day absence days → the absence type;
+     *  - holidays → "Feiertag: …";
+     *  - regular workdays without a booking → blank time cells (a visible gap);
+     *  - weekends without anything → dashes and no label.
+     *
+     * Pure (no PDF/DB side effects) so it can be unit-tested.
+     *
+     * @param TimeEntry[] $timeEntries
+     * @param Absence[] $absences
+     * @param Holiday[] $holidays
+     * @param array<int, string> $projectNames id => name
+     * @return list<array{date: string, day: string, start: string, end: string, break: string, work: string, project: string, note: string, fill: bool}>
+     */
+    private function buildDayRows(array $timeEntries, array $absences, array $holidays, int $year, int $month, array $projectNames): array {
+        // Holiday lookup
+        $holidayDates = [];
+        foreach ($holidays as $holiday) {
+            $holidayDates[$holiday->getDate()->format('Y-m-d')] = $holiday->getName();
+        }
+
+        // Absence lookup per calendar day: expand each absence's start–end range
+        // to individual dates. Rejected/cancelled absences are ignored — they
+        // did not actually happen.
+        $absencesByDate = [];
+        foreach ($absences as $absence) {
+            if (in_array($absence->getStatus(), [Absence::STATUS_REJECTED, Absence::STATUS_CANCELLED], true)) {
+                continue;
+            }
+            $cursor = clone $absence->getStartDate();
+            $absenceEnd = $absence->getEndDate();
+            while ($cursor <= $absenceEnd) {
+                $absencesByDate[$cursor->format('Y-m-d')] = $absence;
+                $cursor->modify('+1 day');
+            }
+        }
+
+        // Entries by date
+        $entriesByDate = [];
+        foreach ($timeEntries as $entry) {
+            $entriesByDate[$entry->getDate()->format('Y-m-d')][] = $entry;
+        }
+
+        $rows = [];
         $startDate = new DateTime("$year-$month-01");
         $endDate = (clone $startDate)->modify('last day of this month');
         $current = clone $startDate;
@@ -385,76 +433,94 @@ class PdfService {
             $dayOfWeek = (int)$current->format('N');
             $isWeekend = $dayOfWeek > 5;
             $isHoliday = isset($holidayDates[$dateStr]);
+            $fill = $isWeekend || $isHoliday;
 
-            // Background color for weekends/holidays
-            if ($isWeekend || $isHoliday) {
-                $pdf->SetFillColor(245, 245, 245);
-                $fill = true;
-            } else {
-                $fill = false;
-            }
+            $date = $current->format('d.m.Y');
+            $day = $this->getGermanDayName($dayOfWeek);
 
-            $dateFormatted = $current->format('d.m.Y');
-            $dayName = $this->getGermanDayName($dayOfWeek);
+            $absence = $absencesByDate[$dateStr] ?? null;
+            $absenceLabel = $absence !== null
+                ? $absence->getTypeName() . ($absence->isHalfDay() ? ' (halber Tag)' : '')
+                : '';
 
             if (isset($entriesByDate[$dateStr])) {
-                // Has time entries
                 foreach ($entriesByDate[$dateStr] as $entry) {
-                    $this->renderTimeEntryRow(
-                        $pdf,
-                        $dateFormatted,
-                        $dayName,
-                        $entry->getStartTime()->format('H:i'),
-                        $entry->getEndTime()->format('H:i'),
-                        $this->formatMinutes($entry->getBreakMinutes()),
-                        $this->formatMinutes($entry->getWorkMinutes()),
-                        $entry->getProjectId() !== null ? ($projectNames[$entry->getProjectId()] ?? '') : '',
-                        $entry->getDescription() ?? '',
-                        $fill
-                    );
-                    $dateFormatted = ''; // Clear for subsequent entries on same day
-                    $dayName = '';
+                    $rows[] = [
+                        'date' => $date,
+                        'day' => $day,
+                        'start' => $entry->getStartTime()->format('H:i'),
+                        'end' => $entry->getEndTime()->format('H:i'),
+                        'break' => $this->formatMinutes($entry->getBreakMinutes()),
+                        'work' => $this->formatMinutes($entry->getWorkMinutes()),
+                        'project' => $entry->getProjectId() !== null ? ($projectNames[$entry->getProjectId()] ?? '') : '',
+                        'note' => $entry->getDescription() ?? '',
+                        'fill' => $fill,
+                    ];
+                    $date = ''; // Clear for subsequent entries on the same day
+                    $day = '';
                 }
+                // Only a genuine half-day absence is shown alongside a booking
+                // (morning work + afternoon off). A full-day absence never
+                // coexists with a booking in valid data, so we don't add a
+                // marker row there to avoid a confusing "worked + absent" day.
+                if ($absence !== null && $absence->isHalfDay()) {
+                    $rows[] = $this->markerRow($date, $day, $absenceLabel, $fill);
+                }
+            } elseif ($absence !== null) {
+                // Absence day (#318): show the type directly in the day row.
+                $rows[] = $this->markerRow($date, $day, $absenceLabel, $fill);
             } elseif ($isHoliday) {
-                // Holiday
-                $this->renderTimeEntryRow(
-                    $pdf,
-                    $dateFormatted,
-                    $dayName,
-                    '-',
-                    '-',
-                    '-',
-                    '-',
-                    '',
-                    'Feiertag: ' . $holidayDates[$dateStr],
-                    $fill
-                );
+                $rows[] = $this->markerRow($date, $day, 'Feiertag: ' . $holidayDates[$dateStr], $fill);
             } elseif (!$isWeekend) {
-                // Regular workday without entry
-                $this->renderTimeEntryRow(
-                    $pdf,
-                    $dateFormatted,
-                    $dayName,
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    $fill
-                );
+                // Regular workday without entry: blank cells signal a gap
+                // (a missing booking that may need attention).
+                $rows[] = [
+                    'date' => $date, 'day' => $day, 'start' => '', 'end' => '',
+                    'break' => '', 'work' => '', 'project' => '', 'note' => '', 'fill' => $fill,
+                ];
+            } else {
+                // Weekend without entry/absence: show the day so the overview is
+                // gap-free (#318), with dashes and no label — the "Sa"/"So" day
+                // and grey shading already mark it as a non-working day.
+                $rows[] = $this->markerRow($date, $day, '', $fill);
             }
 
             $current->modify('+1 day');
         }
 
-        $pdf->Ln(5);
+        return $rows;
+    }
+
+    /**
+     * A non-working day row: dashes in the time columns plus an optional note.
+     *
+     * @return array{date: string, day: string, start: string, end: string, break: string, work: string, project: string, note: string, fill: bool}
+     */
+    private function markerRow(string $date, string $day, string $note, bool $fill): array {
+        return [
+            'date' => $date, 'day' => $day, 'start' => '-', 'end' => '-',
+            'break' => '-', 'work' => '-', 'project' => '', 'note' => $note, 'fill' => $fill,
+        ];
+    }
+
+    /**
+     * Move to the next page if the given block height would not fit in the
+     * remaining space on the current page. Keeps a section (heading + content)
+     * from being orphaned across a page break (#318).
+     */
+    private function ensureSpace(TCPDF $pdf, float $neededMm): void {
+        if ($pdf->GetY() + $neededMm > $pdf->getPageHeight() - $pdf->getBreakMargin()) {
+            $pdf->AddPage();
+        }
     }
 
     /**
      * Add absences section
      */
     private function addAbsencesSection(TCPDF $pdf, array $absences): void {
+        // Keep heading + table header + at least the first rows together.
+        $this->ensureSpace($pdf, 14 + min(count($absences), 3) * 6 + 5);
+
         $pdf->SetFont(self::FONT_FAMILY, 'B', self::FONT_SIZE_NORMAL);
         $pdf->Cell(0, 8, 'Abwesenheiten', 0, 1);
 
@@ -558,6 +624,9 @@ class PdfService {
      * Add summary section
      */
     private function addSummary(TCPDF $pdf, Employee $employee, array $statistics): void {
+        // Keep the whole summary block on one page.
+        $this->ensureSpace($pdf, 48);
+
         $pdf->SetFont(self::FONT_FAMILY, 'B', self::FONT_SIZE_NORMAL);
         $pdf->Cell(0, 8, 'Zusammenfassung', 0, 1);
 
@@ -608,6 +677,9 @@ class PdfService {
      * Add signature section
      */
     private function addSignatureSection(TCPDF $pdf): void {
+        // Keep the confirmation text + signature lines together on one page.
+        $this->ensureSpace($pdf, 50);
+
         $pdf->Ln(10);
 
         $pdf->SetFont(self::FONT_FAMILY, '', self::FONT_SIZE_SMALL);
@@ -673,6 +745,9 @@ class PdfService {
      * Add approval info section to PDF (two columns: submitted / approved)
      */
     private function addApprovalInfoSection(TCPDF $pdf, array $approvalInfo): void {
+        // Keep the approval info block together on one page.
+        $this->ensureSpace($pdf, 45);
+
         $pdf->Ln(10);
 
         // Extract data

--- a/tests/Unit/Service/PdfServiceTest.php
+++ b/tests/Unit/Service/PdfServiceTest.php
@@ -150,6 +150,28 @@ class PdfServiceTest extends TestCase {
         $this->assertSame('', $byDay['22.06.2026'][0]['start']);
     }
 
+    public function testCancelledAbsenceIsIgnored(): void {
+        // Like a rejected absence, a cancelled one must not appear in the day row.
+        $absences = [$this->absence(Absence::TYPE_VACATION, '2026-06-22', '2026-06-22', Absence::STATUS_CANCELLED)];
+
+        $byDay = $this->rowsByDay([], $absences, [], 2026, 6);
+
+        $this->assertCount(1, $byDay['22.06.2026']);
+        $this->assertSame('', $byDay['22.06.2026'][0]['note']);
+        $this->assertSame('', $byDay['22.06.2026'][0]['start']);
+    }
+
+    public function testPendingAbsenceIsShown(): void {
+        // A still-pending (planned) absence is intentionally visible in the
+        // overview — only rejected/cancelled ones are filtered out.
+        $absences = [$this->absence(Absence::TYPE_VACATION, '2026-06-22', '2026-06-22', Absence::STATUS_PENDING)];
+
+        $byDay = $this->rowsByDay([], $absences, [], 2026, 6);
+
+        $this->assertSame('Urlaub', $byDay['22.06.2026'][0]['note']);
+        $this->assertSame('-', $byDay['22.06.2026'][0]['start']);
+    }
+
     public function testHolidayShowsLabel(): void {
         $holidays = [$this->holiday('2026-06-18', 'Testfeiertag')];
 

--- a/tests/Unit/Service/PdfServiceTest.php
+++ b/tests/Unit/Service/PdfServiceTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Tests\Unit\Service;
+
+use DateTime;
+use OCA\WorkTime\Db\Absence;
+use OCA\WorkTime\Db\Holiday;
+use OCA\WorkTime\Db\ProjectMapper;
+use OCA\WorkTime\Db\TimeEntry;
+use OCA\WorkTime\Service\CompanySettingsService;
+use OCA\WorkTime\Service\PdfService;
+use OCP\Files\IRootFolder;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Covers the gap-free day overview of the monthly PDF report (#318):
+ * absences shown in the day row, holidays, weekends and blank workdays.
+ */
+class PdfServiceTest extends TestCase {
+
+    private PdfService $service;
+    private ReflectionMethod $buildDayRows;
+
+    protected function setUp(): void {
+        $this->service = new PdfService(
+            $this->createMock(CompanySettingsService::class),
+            $this->createMock(IRootFolder::class),
+            $this->createMock(ProjectMapper::class),
+        );
+        $this->buildDayRows = new ReflectionMethod(PdfService::class, 'buildDayRows');
+        $this->buildDayRows->setAccessible(true);
+    }
+
+    /**
+     * @return array<string, array<int, array<string, mixed>>> day (d.m.Y) => rows,
+     *   with the date carried forward across multi-row days.
+     */
+    private function rowsByDay(array $timeEntries, array $absences, array $holidays, int $year, int $month, array $projectNames = []): array {
+        $rows = $this->buildDayRows->invoke($this->service, $timeEntries, $absences, $holidays, $year, $month, $projectNames);
+        $byDay = [];
+        $current = null;
+        foreach ($rows as $row) {
+            if ($row['date'] !== '') {
+                $current = $row['date'];
+            }
+            $byDay[$current][] = $row;
+        }
+        return $byDay;
+    }
+
+    private function entry(string $date, string $start, string $end, int $break, int $work, ?int $projectId, string $desc): TimeEntry {
+        $e = new TimeEntry();
+        $e->setDate(new DateTime($date));
+        $e->setStartTime(new DateTime("$date $start"));
+        $e->setEndTime(new DateTime("$date $end"));
+        $e->setBreakMinutes($break);
+        $e->setWorkMinutes($work);
+        $e->setProjectId($projectId);
+        $e->setDescription($desc);
+        return $e;
+    }
+
+    private function absence(string $type, string $start, string $end, string $status, float $scope = 1.0): Absence {
+        $a = new Absence();
+        $a->setType($type);
+        $a->setStartDate(new DateTime($start));
+        $a->setEndDate(new DateTime($end));
+        $a->setStatus($status);
+        $a->setScopeValue($scope);
+        return $a;
+    }
+
+    private function holiday(string $date, string $name): Holiday {
+        $h = new Holiday();
+        $h->setDate(new DateTime($date));
+        $h->setName($name);
+        return $h;
+    }
+
+    public function testOverviewIsGapFreeWithOneEntryPerCalendarDay(): void {
+        // June 2026 has 30 days; with no data every day must still produce a row.
+        $byDay = $this->rowsByDay([], [], [], 2026, 6);
+
+        $this->assertCount(30, $byDay);
+        $this->assertArrayHasKey('01.06.2026', $byDay);
+        $this->assertArrayHasKey('30.06.2026', $byDay);
+    }
+
+    public function testFullDayAbsenceShowsTypeInTheDayRow(): void {
+        // Vacation 08.–10.06. with no bookings on those days.
+        $absences = [$this->absence(Absence::TYPE_VACATION, '2026-06-08', '2026-06-10', Absence::STATUS_APPROVED)];
+
+        $byDay = $this->rowsByDay([], $absences, [], 2026, 6);
+
+        foreach (['08.06.2026', '09.06.2026', '10.06.2026'] as $day) {
+            $this->assertCount(1, $byDay[$day]);
+            $this->assertSame('Urlaub', $byDay[$day][0]['note']);
+            $this->assertSame('-', $byDay[$day][0]['start']);
+        }
+    }
+
+    public function testBookingShowsTimesAndProject(): void {
+        $entries = [$this->entry('2026-06-01', '08:00', '16:00', 30, 450, 2, 'Arbeit')];
+
+        $byDay = $this->rowsByDay($entries, [], [], 2026, 6, [2 => 'Projekt X']);
+
+        $row = $byDay['01.06.2026'][0];
+        $this->assertSame('08:00', $row['start']);
+        $this->assertSame('Projekt X', $row['project']);
+        $this->assertSame('Arbeit', $row['note']);
+    }
+
+    public function testHalfDayAbsenceAddsMarkerRowAlongsideBooking(): void {
+        // Morning work + afternoon compensatory leave on the same day.
+        $entries = [$this->entry('2026-06-15', '08:00', '12:00', 0, 240, null, 'Vormittag')];
+        $absences = [$this->absence(Absence::TYPE_COMPENSATORY, '2026-06-15', '2026-06-15', Absence::STATUS_APPROVED, 0.5)];
+
+        $byDay = $this->rowsByDay($entries, $absences, [], 2026, 6);
+
+        $this->assertCount(2, $byDay['15.06.2026']);
+        $this->assertSame('Vormittag', $byDay['15.06.2026'][0]['note']);
+        $this->assertSame('Freizeitausgleich (halber Tag)', $byDay['15.06.2026'][1]['note']);
+        $this->assertSame('-', $byDay['15.06.2026'][1]['start']);
+    }
+
+    public function testFullDayAbsenceWithBookingDoesNotAddMarkerRow(): void {
+        // Contradictory data (full work + full-day vacation): show only the
+        // booking, no confusing "worked + absent" marker row.
+        $entries = [$this->entry('2026-06-09', '08:00', '17:00', 30, 480, null, 'Projektarbeit')];
+        $absences = [$this->absence(Absence::TYPE_VACATION, '2026-06-09', '2026-06-09', Absence::STATUS_APPROVED)];
+
+        $byDay = $this->rowsByDay($entries, $absences, [], 2026, 6);
+
+        $this->assertCount(1, $byDay['09.06.2026']);
+        $this->assertSame('Projektarbeit', $byDay['09.06.2026'][0]['note']);
+    }
+
+    public function testRejectedAbsenceIsIgnored(): void {
+        // 22.06.2026 is a Monday; a rejected absence must not appear, leaving a
+        // blank workday row (empty time cells, not dashes).
+        $absences = [$this->absence(Absence::TYPE_VACATION, '2026-06-22', '2026-06-22', Absence::STATUS_REJECTED)];
+
+        $byDay = $this->rowsByDay([], $absences, [], 2026, 6);
+
+        $this->assertCount(1, $byDay['22.06.2026']);
+        $this->assertSame('', $byDay['22.06.2026'][0]['note']);
+        $this->assertSame('', $byDay['22.06.2026'][0]['start']);
+    }
+
+    public function testHolidayShowsLabel(): void {
+        $holidays = [$this->holiday('2026-06-18', 'Testfeiertag')];
+
+        $byDay = $this->rowsByDay([], [], $holidays, 2026, 6);
+
+        $this->assertSame('Feiertag: Testfeiertag', $byDay['18.06.2026'][0]['note']);
+        $this->assertSame('-', $byDay['18.06.2026'][0]['start']);
+    }
+
+    public function testWeekendRowHasDashesAndNoLabel(): void {
+        // 06.06.2026 is a Saturday: dashes, empty note, grey fill.
+        $byDay = $this->rowsByDay([], [], [], 2026, 6);
+
+        $row = $byDay['06.06.2026'][0];
+        $this->assertSame('-', $row['start']);
+        $this->assertSame('', $row['note']);
+        $this->assertTrue($row['fill']);
+    }
+}


### PR DESCRIPTION
Umsetzung des Feature-Wunsches von udodahl (#318): vollständige Tagesübersicht im PDF-Monatsbericht.

## Problem

Die Tagestabelle hatte Lücken: Abwesenheitstage (Urlaub, Kind krank, …) erschienen nur im separaten Abschnitt unter der Tabelle, Wochenenden gar nicht. Der Vergleich von Dienstplan und gemeldeten Zeiten war dadurch umständlich.

## Lösung

Jeder Kalendertag erzeugt jetzt mindestens eine Zeile:

- **Abwesenheitstage** zeigen den Typ direkt in der Tageszeile („Urlaub", „Kind krank", „Freizeitausgleich" …).
- **Wochenenden** erscheinen mit `–` und grauer Schattierung, **ohne Label** — Sa/So markieren den freien Tag eindeutig (bewusst kein „frei", um Verwechslung mit „Freizeitausgleich" zu vermeiden).
- **Echte halbe Tage** (vormittags Arbeit + nachmittags frei) zeigen die Buchung plus einen Marker „… (halber Tag)". Ein Ganztags-Widerspruch (Buchung trotz Ganztags-Abwesenheit) erzeugt **keine** zusätzliche Markerzeile.
- **Feiertage** und **Buchungen** wie bisher.

Zusätzlich: Die Blöcke **„Abwesenheiten", „Zusammenfassung", Signatur und Genehmigung** springen als Ganzes auf die nächste Seite, wenn sie nicht mehr komplett auf die aktuelle Seite passen — kein verwaister Block-Header mehr.

## Tests

Die Pro-Tag-Logik ist in die reine Methode `buildDayRows()` ausgelagert und durch `PdfServiceTest` abgedeckt (8 Fälle): lückenlos, Abwesenheitstyp am richtigen Tag, Halbtags-Marker, Ganztags-Edgecase ohne Marker, abgelehnte Abwesenheit ignoriert, Feiertag, Wochenende.

## Verifikation

Live gegen die Docker-Instanz gerendert (Februar + Juni 2026, echte Testdaten); Output nach dem Refactor byte-identisch zur manuell geprüften Version. PHP-Lint grün.

Fixes #318