### PR TITLE
fix(absence): Genehmigung ohne eigenes Mitarbeiter-Profil ermöglichen

### DIFF
--- a/lib/Controller/AbsenceController.php
+++ b/lib/Controller/AbsenceController.php
@@ -226,12 +226,13 @@ class AbsenceController extends BaseController {
                 return $this->forbiddenResponse();
             }
 
+            // The approver does not need an own employee profile: HR/Admins may
+            // manage staff without being tracked as employees themselves. If no
+            // profile exists, approvedBy stays null (same as reject()).
             $approverEmployee = $this->permissionService->getEmployeeForUser($this->userId);
-            if (!$approverEmployee) {
-                return $this->successResponse(['error' => 'Approver not found'], 400);
-            }
+            $approverEmployeeId = $approverEmployee?->getId();
 
-            $absence = $this->absenceService->approve($id, $approverEmployee->getId(), $this->userId);
+            $absence = $this->absenceService->approve($id, $approverEmployeeId, $this->userId);
 
             return $this->successResponse($absence);
         } catch (\Exception $e) {

--- a/lib/Service/AbsenceService.php
+++ b/lib/Service/AbsenceService.php
@@ -308,7 +308,7 @@ class AbsenceService {
     /**
      * @throws NotFoundException
      */
-    public function approve(int $id, int $approverEmployeeId, string $currentUserId = ''): Absence {
+    public function approve(int $id, ?int $approverEmployeeId, string $currentUserId = ''): Absence {
         $absence = $this->find($id);
         $oldValues = $absence->jsonSerialize();
 

--- a/tests/Unit/Service/AbsenceServiceTest.php
+++ b/tests/Unit/Service/AbsenceServiceTest.php
@@ -237,4 +237,22 @@ class AbsenceServiceTest extends TestCase {
 
         $this->service->delete(99, 'admin', 'Korrektur nach Rückfrage', true);
     }
+
+    /**
+     * Regression (#approve-without-profile): an HR/Admin approver that has no own
+     * employee profile (approverEmployeeId === null) must still be able to approve.
+     * The absence becomes APPROVED with approvedBy left null — no exception, no
+     * "Approver not found" abort.
+     */
+    public function testApproveSucceedsWithoutApproverEmployeeProfile(): void {
+        $pending = $this->makeAbsence(Absence::TYPE_VACATION, Absence::STATUS_PENDING, new DateTime('2026-07-13'), new DateTime('2026-07-13'));
+        $this->absenceMapper->method('find')->with(99)->willReturn($pending);
+        $this->absenceMapper->method('update')->willReturnArgument(0);
+
+        $result = $this->service->approve(99, null, 'admin');
+
+        $this->assertSame(Absence::STATUS_APPROVED, $result->getStatus());
+        $this->assertNull($result->getApprovedBy());
+        $this->assertNotNull($result->getApprovedAt());
+    }
 }


### PR DESCRIPTION
## Problem
Als Admin/HR ließ sich ein beantragter Urlaub **nicht genehmigen** – Toast "Fehler beim Genehmigen". "Ablehnen" funktionierte. (Extern gemeldet, NC 32.0.1 / WorkTime 0.11.0.)

## Ursache
`AbsenceController::approve()` brach mit HTTP 400 "Approver not found" ab, wenn der genehmigende User keinen eigenen `wt_employees`-Datensatz hatte. `reject()` hatte diese Hürde nicht – daher ging Ablehnen, aber nicht Genehmigen.

## Fix
- Genehmigung verlangt kein eigenes Mitarbeiter-Profil mehr; `approvedBy` bleibt `null`, wenn keins existiert (wie bei `reject()`).
- `successResponse(...,400)`-Anti-Pattern entfernt; `AbsenceService::approve()` akzeptiert nullable `approverEmployeeId`.

## Test
- Unit-Regressionstest: Genehmigung durch User ohne Profil → Status `approved`, `approvedBy` null (rot→grün gegen alten Stand verifiziert).
- Live: normale Genehmigung (Approver mit Profil) weiterhin 200/approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)