### PR TITLE
feat: Rekursive Team-Sicht — Vorgesetzter sieht Unterbaum (#347)

### DIFF
--- a/lib/Controller/AbsenceController.php
+++ b/lib/Controller/AbsenceController.php
@@ -336,8 +336,8 @@ class AbsenceController extends BaseController {
         }
 
         // Admin/HR see everything unmasked across all employees.
-        // Supervisors only see their own team (employees whose supervisorId matches them)
-        // and only their team unmasked. Everyone else falls back to per-employee visibility rules.
+        // Supervisors see their whole subtree (recursive) unmasked incl. pending (#347).
+        // Everyone else falls back to per-employee visibility rules.
         $isPrivileged = $this->permissionService->canManageEmployees($this->userId);
         $isSupervisor = $this->permissionService->isSupervisor($this->userId);
 

--- a/lib/Controller/AbsenceController.php
+++ b/lib/Controller/AbsenceController.php
@@ -344,7 +344,14 @@ class AbsenceController extends BaseController {
         $currentEmployee = $this->permissionService->getEmployeeForUser($this->userId);
         $currentEmployeeId = $currentEmployee?->getId();
 
-        $supervisorEmployeeId = $isSupervisor ? $currentEmployeeId : null;
+        // Sicht (#347): ein Vorgesetzter sieht seinen ganzen Unterbaum rekursiv,
+        // nicht nur direkte Unterstellte. Genehmigen bleibt davon unberuehrt.
+        $subtreeEmployeeIds = ($isSupervisor && $currentEmployeeId !== null)
+            ? array_map(
+                static fn($e) => $e->getId(),
+                $this->permissionService->getSubordinateEmployees($currentEmployeeId)
+            )
+            : [];
 
         $overview = $this->absenceService->getAbsenceOverview(
             $year,
@@ -352,7 +359,7 @@ class AbsenceController extends BaseController {
             $this->userId,
             $isPrivileged,
             $currentEmployeeId,
-            $supervisorEmployeeId
+            $subtreeEmployeeIds
         );
 
         return $this->successResponse($overview);

--- a/lib/Controller/ReportController.php
+++ b/lib/Controller/ReportController.php
@@ -646,7 +646,9 @@ class ReportController extends BaseController {
             return $authError;
         }
 
-        $teamMembers = $this->permissionService->getTeamMembers($this->userId);
+        // Sicht (#347): rekursiv ueber den ganzen Unterbaum. Genehmigen bleibt
+        // direkt (siehe Genehmigungen/pendingMonths).
+        $teamMembers = $this->permissionService->getVisibleTeamMembers($this->userId);
 
         if (empty($teamMembers)) {
             return $this->successResponse([]);

--- a/lib/Service/AbsenceService.php
+++ b/lib/Service/AbsenceService.php
@@ -532,17 +532,19 @@ class AbsenceService {
      *
      * @return array[] Array of { employeeId, employeeName, absences }
      */
-    public function getAbsenceOverview(int $year, int $month, string $currentUserId, bool $isPrivileged, ?int $currentEmployeeId, ?int $supervisorEmployeeId): array {
+    /**
+     * @param int[] $subtreeEmployeeIds Employees the viewer supervises (recursively, #347) — these are shown unmasked incl. pending. Empty for non-supervisors.
+     */
+    public function getAbsenceOverview(int $year, int $month, string $currentUserId, bool $isPrivileged, ?int $currentEmployeeId, array $subtreeEmployeeIds = []): array {
         $allEmployees = $this->employeeMapper->findAllActive();
         $result = [];
 
         foreach ($allEmployees as $employee) {
-            if (!$this->isEmployeeVisibleInOverview($employee, $isPrivileged, $currentEmployeeId, $supervisorEmployeeId)) {
+            if (!$this->isEmployeeVisibleInOverview($employee, $isPrivileged, $currentEmployeeId, $subtreeEmployeeIds)) {
                 continue;
             }
 
-            $isTeamMember = $supervisorEmployeeId !== null
-                && $employee->getSupervisorId() === $supervisorEmployeeId;
+            $isTeamMember = in_array($employee->getId(), $subtreeEmployeeIds, true);
             $unmasked = $isPrivileged || $isTeamMember;
 
             // Status-Kalender (#345): wer den Mitarbeiter unmaskiert sieht (Admin/HR
@@ -591,7 +593,7 @@ class AbsenceService {
     /**
      * Check if an employee's absences should be visible to the current user.
      */
-    private function isEmployeeVisibleInOverview(Employee $employee, bool $isPrivileged, ?int $currentEmployeeId, ?int $supervisorEmployeeId): bool {
+    private function isEmployeeVisibleInOverview(Employee $employee, bool $isPrivileged, ?int $currentEmployeeId, array $subtreeEmployeeIds): bool {
         // Admin/HR see all employees
         if ($isPrivileged) {
             return true;
@@ -602,8 +604,9 @@ class AbsenceService {
             return true;
         }
 
-        // Supervisors see their own team members regardless of per-employee visibility setting
-        if ($supervisorEmployeeId !== null && $employee->getSupervisorId() === $supervisorEmployeeId) {
+        // Supervisors see everyone in their (recursive) subtree, regardless of
+        // the per-employee visibility setting.
+        if (in_array($employee->getId(), $subtreeEmployeeIds, true)) {
             return true;
         }
 

--- a/lib/Service/AbsenceService.php
+++ b/lib/Service/AbsenceService.php
@@ -530,10 +530,8 @@ class AbsenceService {
     /**
      * Get absence overview for all visible employees in a given month.
      *
+     * @param int[] $subtreeEmployeeIds Employees the viewer supervises (recursively, #347) — shown unmasked incl. pending. Empty for non-supervisors.
      * @return array[] Array of { employeeId, employeeName, absences }
-     */
-    /**
-     * @param int[] $subtreeEmployeeIds Employees the viewer supervises (recursively, #347) — these are shown unmasked incl. pending. Empty for non-supervisors.
      */
     public function getAbsenceOverview(int $year, int $month, string $currentUserId, bool $isPrivileged, ?int $currentEmployeeId, array $subtreeEmployeeIds = []): array {
         $allEmployees = $this->employeeMapper->findAllActive();

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -201,6 +201,56 @@ class PermissionService {
     }
 
     /**
+     * Team members a user may SEE (calendar, evaluation) — recursively over the
+     * whole subtree (#347). A higher-level manager sees everyone below them.
+     * Genehmigen bleibt davon UNBERUEHRT: dafuer gilt weiterhin der direkte
+     * Vorgesetzte (canApprove / getTeamMembers, eine Ebene).
+     *
+     * @return Employee[]
+     */
+    public function getVisibleTeamMembers(string $userId): array {
+        // Admin and HR Manager see all active employees
+        if ($this->isAdmin($userId) || $this->isHrManager($userId)) {
+            return $this->employeeMapper->findAllActive();
+        }
+
+        $employee = $this->getEmployeeForUser($userId);
+        if ($employee === null) {
+            return [];
+        }
+
+        return $this->getSubordinateEmployees($employee->getId());
+    }
+
+    /**
+     * All employees in the subtree below the given employee (direct AND indirect
+     * reports), via the supervisor relation. Cycle-guarded; the root itself is
+     * not included. For SIGHT only — not for approval.
+     *
+     * @return Employee[]
+     */
+    public function getSubordinateEmployees(int $rootEmployeeId): array {
+        $result = [];
+        $visited = [$rootEmployeeId => true];
+        $queue = [$rootEmployeeId];
+
+        while (!empty($queue)) {
+            $current = array_shift($queue);
+            foreach ($this->employeeMapper->findBySupervisor($current) as $report) {
+                $id = $report->getId();
+                if (isset($visited[$id])) {
+                    continue; // protect against accidental supervisor cycles
+                }
+                $visited[$id] = true;
+                $result[] = $report;
+                $queue[] = $id;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Get permission info for frontend
      */
     public function getPermissionInfo(string $userId): array {

--- a/tests/Unit/Service/AbsenceServiceTest.php
+++ b/tests/Unit/Service/AbsenceServiceTest.php
@@ -295,8 +295,8 @@ class AbsenceServiceTest extends TestCase {
             $this->ovAbsence(1, Absence::STATUS_PENDING),
         ]);
 
-        // Viewer is supervisor (employeeId 10), not privileged.
-        $result = $this->service->getAbsenceOverview(2026, 6, 'sv', false, 10, 10);
+        // Viewer is supervisor (employeeId 10); subtree contains member id 1.
+        $result = $this->service->getAbsenceOverview(2026, 6, 'sv', false, 10, [1]);
 
         $this->assertCount(1, $result);
         $statuses = array_column($result[0]['absences'], 'status');
@@ -317,8 +317,8 @@ class AbsenceServiceTest extends TestCase {
             $this->ovAbsence(1, Absence::STATUS_APPROVED),
         ]);
 
-        // Viewer is a normal employee (id 2), not privileged, not a supervisor.
-        $result = $this->service->getAbsenceOverview(2026, 6, 'peer', false, 2, null);
+        // Viewer is a normal employee (id 2), not privileged, no subtree.
+        $result = $this->service->getAbsenceOverview(2026, 6, 'peer', false, 2, []);
 
         $this->assertCount(1, $result);
         $statuses = array_column($result[0]['absences'], 'status');

--- a/tests/Unit/Service/PermissionServiceTest.php
+++ b/tests/Unit/Service/PermissionServiceTest.php
@@ -333,4 +333,58 @@ class PermissionServiceTest extends TestCase {
 
         $this->service->setHrManagers(['user:new_hr', 'group:new_group']);
     }
+
+    // ---------------------------------------------------------------------
+    // #347: recursive subtree for SIGHT (getSubordinateEmployees)
+    // ---------------------------------------------------------------------
+
+    private function subEmp(int $id, ?int $supervisorId): Employee {
+        $e = new Employee();
+        $e->setId($id);
+        $e->setSupervisorId($supervisorId);
+        $e->setFirstName('E');
+        $e->setLastName((string)$id);
+        return $e;
+    }
+
+    /**
+     * #347: getSubordinateEmployees walks the whole subtree (direct + indirect),
+     * e.g. Frank(10) → Anna(20) → Ben(30)/Carla(31).
+     */
+    public function testGetSubordinateEmployeesIsRecursive(): void {
+        $anna = $this->subEmp(20, 10);
+        $ben = $this->subEmp(30, 20);
+        $carla = $this->subEmp(31, 20);
+        $this->employeeMapper->method('findBySupervisor')->willReturnCallback(
+            fn(int $sid): array => match ($sid) {
+                10 => [$anna],
+                20 => [$ben, $carla],
+                default => [],
+            }
+        );
+
+        $ids = array_map(fn(Employee $e) => $e->getId(), $this->service->getSubordinateEmployees(10));
+        sort($ids);
+        $this->assertSame([20, 30, 31], $ids);
+    }
+
+    /**
+     * #347: an accidental supervisor cycle must not loop forever.
+     */
+    public function testGetSubordinateEmployeesHandlesCycles(): void {
+        $a = $this->subEmp(2, 1);
+        $b = $this->subEmp(3, 2);
+        $this->employeeMapper->method('findBySupervisor')->willReturnCallback(
+            fn(int $sid): array => match ($sid) {
+                1 => [$a],
+                2 => [$b],
+                3 => [$a], // cycle back to id 2's subtree
+                default => [],
+            }
+        );
+
+        $ids = array_map(fn(Employee $e) => $e->getId(), $this->service->getSubordinateEmployees(1));
+        sort($ids);
+        $this->assertSame([2, 3], $ids); // each visited once, no infinite loop
+    }
 }


### PR DESCRIPTION
**Phase 4 (Abschluss von #336)** — backend-only.

> Bitte reviewen, noch nicht mergen. Läuft auf Docker (Admin-Pfad unverändert).

## Prinzip
Sicht (Kalender, Auswertung) wird **rekursiv** über den ganzen Unterbaum — ein übergeordneter Manager sieht alle Mitarbeitenden unter sich. **Genehmigen bleibt beim direkten Vorgesetzten** (eine Ebene) → Verantwortung eindeutig, kein versehentliches Durchgreifen.

## Änderungen
- `PermissionService::getVisibleTeamMembers()` (rekursiv) + `getSubordinateEmployees()` (BFS über `supervisorId`, **zyklen-geschützt**). `getTeamMembers()` bleibt **direkt** (Approval-Scope unverändert).
- `ReportController::teamYear` → `getVisibleTeamMembers` (Auswertung→Mitarbeiter).
- `AbsenceController::overview` + `AbsenceService::getAbsenceOverview` → rekursiver Subtree statt nur direkter Unterstellter (Team-Kalender). **Datenschutz/Maskierung für Nicht-Subtree-Kollegen unverändert** (nur Subtree wird unmaskiert + pending gezeigt).

## Tests (PHPUnit, rot→grün)
- `getSubordinateEmployees`: 3-Ebenen-Baum (Frank→Anna→Ben/Carla) → liefert ganzen Unterbaum.
- Zyklen-Schutz: künstlicher Zyklus → kein Endlos-Loop.
- Overview-Tests an neue Subtree-Signatur angepasst (Supervisor sieht pending, Kollege nicht).

## QA (lokal)
Overview-Endpoint 200, Team-Kalender + Auswertung laden fehlerfrei (Admin-Pfad unverändert, da privilegiert = alle).

Closes #347 · Refs #336