### PR TITLE
fix(report): Wochenstunden im PDF-Header aus monatsgültigem Profil (#356)

### DIFF
--- a/lib/Service/PdfService.php
+++ b/lib/Service/PdfService.php
@@ -32,6 +32,7 @@ class PdfService {
         private CompanySettingsService $settingsService,
         private IRootFolder $rootFolder,
         private ProjectMapper $projectMapper,
+        private WorkScheduleService $workScheduleService,
     ) {
     }
 
@@ -101,7 +102,7 @@ class PdfService {
         $pdf = $this->createPdf();
 
         // Header
-        $this->addHeader($pdf, $employee, $periodLabel);
+        $this->addHeader($pdf, $employee, $periodLabel, $startDate);
 
         // Time entries table
         $this->addTimeEntriesTable($pdf, $timeEntries, $absences, $holidays, $startDate, $endDate);
@@ -334,7 +335,7 @@ class PdfService {
     /**
      * Add header with company name and employee info
      */
-    private function addHeader(TCPDF $pdf, Employee $employee, string $periodLabel): void {
+    private function addHeader(TCPDF $pdf, Employee $employee, string $periodLabel, DateTime $periodStart): void {
         $companyName = $this->settingsService->getCompanyName();
 
         // Company name
@@ -368,7 +369,11 @@ class PdfService {
         $pdf->SetFont(self::FONT_FAMILY, 'B', self::FONT_SIZE_NORMAL);
         $pdf->Cell(40, 6, 'Wochenstunden:', 0, 0);
         $pdf->SetFont(self::FONT_FAMILY, '', self::FONT_SIZE_NORMAL);
-        $pdf->Cell(0, 6, number_format((float)$employee->getWeeklyHours(), 1, ',', '.') . ' Std.', 0, 1);
+        // Wochenstunden des im Berichtszeitraum gültigen Arbeitszeitprofils anzeigen,
+        // nicht das aktuelle Mitarbeiter-Feld – sonst weicht der Kopf bei mehreren
+        // Profilen von der zeitraumgültigen Soll-Berechnung ab (#356).
+        $weeklyHours = $this->workScheduleService->getScheduleForDate($employee->getId(), $periodStart)->getWeeklyHours();
+        $pdf->Cell(0, 6, number_format($weeklyHours, 1, ',', '.') . ' Std.', 0, 1);
 
         $pdf->Ln(5);
     }

--- a/tests/Unit/Service/PdfServiceTest.php
+++ b/tests/Unit/Service/PdfServiceTest.php
@@ -11,6 +11,7 @@ use OCA\WorkTime\Db\ProjectMapper;
 use OCA\WorkTime\Db\TimeEntry;
 use OCA\WorkTime\Service\CompanySettingsService;
 use OCA\WorkTime\Service\PdfService;
+use OCA\WorkTime\Service\WorkScheduleService;
 use OCP\Files\IRootFolder;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -30,6 +31,7 @@ class PdfServiceTest extends TestCase {
             $this->createMock(CompanySettingsService::class),
             $this->createMock(IRootFolder::class),
             $this->createMock(ProjectMapper::class),
+            $this->createMock(WorkScheduleService::class),
         );
         $this->buildDayRows = new ReflectionMethod(PdfService::class, 'buildDayRows');
         $this->buildDayRows->setAccessible(true);


### PR DESCRIPTION
Behebt **#356** (extern gemeldet von jam-ch).

## Problem
Im Arbeitszeitnachweis-PDF zeigte der Kopf „Wochenstunden" das **aktuelle** Mitarbeiter-Feld (`$employee->getWeeklyHours()`) statt das **im Berichtszeitraum gültige** Arbeitszeitprofil. Bei mehreren Profilen (Pensumwechsel) wich der Kopf damit von Tagesauflistung und Soll-Berechnung ab, die bereits das zeitraumgültige Profil über `WorkScheduleService` verwenden.

## Fix
`addHeader` nutzt jetzt `WorkScheduleService::getScheduleForDate($employee->getId(), $periodStart)->getWeeklyHours()`. Dazu wird `WorkScheduleService` in `PdfService` injiziert und das Startdatum an `addHeader` durchgereicht. Test-Konstruktor um den Mock ergänzt.

## Verifikation (Playwright, lokal, echtes PDF)
Mitarbeiter mit zwei Profilen (40h ab 2026-05-01, 30h ab 2026-06-01), PDF-Content per FlateDecode entpackt und Kopf ausgelesen:
- **Mai 2026** → „40,0 Std." (vorher fälschlich 30,0) ✅
- **Juni 2026** → „30,0 Std." ✅

Soll-Werte (168:00 Mai / 114:00 Juni) bleiben korrekt. PHP-Lint sauber, OCP-only.

Fixes #356