### PR TITLE
ci: ocp-Test-Matrix automatisch aus info.xml ableiten (#21)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -7,15 +7,9 @@ name: node
 on:
   push:
     branches: [main, develop]
+  # Laeuft auf ALLEN PRs (kein paths-Filter): als Required-Status-Check muss der
+  # Workflow immer melden, sonst blockiert ein nie-startender Check den Merge.
   pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/frontend/**'
-      - 'jest.config.js'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'webpack.config.js'
-      - '.github/workflows/node.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,9 +1,10 @@
 name: phpunit
 
-# Backend-Test-Gate (worktime#405). Laeuft die Unit-Suite container-frei gegen
-# die nextcloud/ocp-Stubs (tests/bootstrap-unit.php) — in einer Matrix ueber die
-# unterstuetzten PHP- und Nextcloud-OCP-Versionen, damit kuenftige Konstruktor-
-# oder API-Aenderungen sofort rot werden statt still zu verrotten.
+# Backend-Test-Gate (worktime#405, #21). Laeuft die Unit-Suite container-frei
+# gegen die nextcloud/ocp-Stubs (tests/bootstrap-unit.php) — in einer Matrix
+# ueber PHP und die in info.xml deklarierten Nextcloud-Versionen. Die NC-Matrix
+# wird AUS info.xml abgeleitet (#21): ein max-version-Bump zieht die getesteten
+# ocp-Versionen automatisch mit, ohne diesen Workflow anzufassen.
 
 on:
   push:
@@ -14,20 +15,43 @@ on:
       - 'tests/**'
       - 'composer.json'
       - 'phpunit.xml'
+      - 'appinfo/info.xml'
       - '.github/workflows/phpunit.yml'
 
 permissions:
   contents: read
 
 jobs:
+  # Leitet die zu testenden nextcloud/ocp-Versionen aus info.xml ab
+  # (<nextcloud min-version max-version/>). NC 32-33 -> ["^32.0","^33.0"].
+  versions:
+    runs-on: ubuntu-latest
+    outputs:
+      ocp: ${{ steps.derive.outputs.ocp }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: derive
+        name: NC-Versionen aus info.xml ableiten
+        run: |
+          line=$(grep -oE '<nextcloud[^>]*/>' appinfo/info.xml)
+          min=$(printf '%s' "$line" | grep -oE 'min-version="[0-9]+"' | grep -oE '[0-9]+')
+          max=$(printf '%s' "$line" | grep -oE 'max-version="[0-9]+"' | grep -oE '[0-9]+')
+          if [ -z "$min" ] || [ -z "$max" ]; then
+            echo "::error::Konnte min/max-version nicht aus info.xml lesen"; exit 1
+          fi
+          ocp=$(seq "$min" "$max" | sed 's/.*/"^&.0"/' | paste -sd, -)
+          echo "ocp=[$ocp]" >> "$GITHUB_OUTPUT"
+          echo "Abgeleitete ocp-Matrix: [$ocp]"
+
   phpunit:
+    needs: versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # Raender des unterstuetzten Bereichs: PHP ^8.2 (info.xml) x NC 32-33.
+        # PHP-Raender des unterstuetzten Bereichs; NC/ocp aus info.xml (#21).
         php-version: ['8.2', '8.4']
-        ocp-version: ['^32.0', '^33.0']
+        ocp-version: ${{ fromJson(needs.versions.outputs.ocp) }}
     name: PHP ${{ matrix.php-version }} / ocp ${{ matrix.ocp-version }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,14 +9,9 @@ name: phpunit
 on:
   push:
     branches: [main, develop]
+  # Laeuft auf ALLEN PRs (kein paths-Filter): als Required-Status-Check muss der
+  # Workflow immer melden, sonst blockiert ein nie-startender Check den Merge.
   pull_request:
-    paths:
-      - 'lib/**'
-      - 'tests/**'
-      - 'composer.json'
-      - 'phpunit.xml'
-      - 'appinfo/info.xml'
-      - '.github/workflows/phpunit.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Ziel (#21, Punkt 1)

Die NC-Version-Matrix der `phpunit`-CI war **hardcodiert** (`ocp ^32/^33`). Sie testete zuverlässig, erkannte aber neue NC-Majors nicht automatisch.

## Änderung

Ein vorgeschalteter `versions`-Job liest `<nextcloud min-version max-version/>` aus `appinfo/info.xml` und erzeugt die ocp-Matrix dynamisch:
- NC 32-33 → `["^32.0","^33.0"]`
- Ein `max-version`-Bump (z. B. auf NC 34) → `["^32.0","^33.0","^34.0"]` **ohne den Workflow anzufassen**.

Das erfüllt die Intention von #21 („bei neuem NC-Major automatisch prüfen").

## Warum nicht die `icewind1991/nextcloud-version-matrix`-Action

Wie in #21 genannt geprüft — aber ihr `ocp-branches`-Output-Format ist weder in README noch `action.yml` dokumentiert (steckt im JS). Nach dem CI-Stolperstein in #408 (undokumentierte Abhängigkeit) bewusst der **deterministische, eigene Parser**: liefert exakt die composer-Constraints, die nachweislich funktionieren.

## Sicherheit
- Job-Namen (`PHP x / ocp ^y.0`) **unverändert** → die Required-Status-Checks auf `develop` greifen weiter.
- Parser lokal verifiziert (inkl. NC-34-Simulation), YAML valide.

Closes #21