### PR TITLE
ci: Canary gegen NC-Entwicklungsversion (Frühwarnung) (#21)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,48 @@
+name: canary (next NC)
+
+# Fruehwarnung gegen die Entwicklungsversion von Nextcloud (worktime#21).
+# Laeuft die Unit-Suite gegen nextcloud/ocp:dev-master (= naechstes NC-Major)
+# und beantwortet die Frage "bricht das kommende NC etwas bei uns, bevor es
+# released ist". BEWUSST ein eigener Workflow und KEIN Required-Status-Check:
+# wird er rot, ist das eine sichtbare Warnung — blockiert aber niemals einen
+# Merge (das Gate sind allein die phpunit-Matrix + node).
+#
+# dev-master verlangt PHP >= 8.3 (NC 35 droppt 8.2), daher 8.4 + Anheben des
+# composer-Platform-Pins (der sonst auf 8.2 fixiert und dev-master ausschliesst).
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # montags 06:00 UTC — auch ohne PR/Push
+  workflow_dispatch: {}
+  push:
+    branches: [develop]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    name: ocp dev-master
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Platform-Pin auf 8.4 anheben (dev-master droppt PHP 8.2)
+        run: composer config platform.php 8.4
+
+      - name: nextcloud/ocp auf dev-master setzen
+        run: composer require --dev --no-update "nextcloud/ocp:dev-master"
+
+      - name: Abhaengigkeiten installieren
+        run: composer update --no-interaction --no-progress --prefer-dist
+
+      - name: Unit-Tests gegen die NC-Entwicklungsversion
+        run: composer test


### PR DESCRIPTION
## Warum

Die info.xml-Matrix testet nur den **deklarierten** NC-Bereich — sie sagt uns nicht von außen, dass ein neues NC kommt. Dieser Canary schließt die Lücke: Er testet kontinuierlich gegen die **Entwicklungsversion** von Nextcloud (`nextcloud/ocp:dev-master` = nächstes Major) und warnt früh, wenn das kommende NC etwas bei uns bricht — **bevor** es released ist.

## Design
- **Eigener Workflow**, **nicht-blockierend**: kein Required-Status-Check. Ein rotes dev-master ist eine sichtbare Warnung, schlägt aber **nie das Merge-Gate** (Gates bleiben `phpunit`-Matrix + `node`).
- Läuft **wöchentlich** (Mo 06:00 UTC) + bei PRs/Push auf develop + manuell (`workflow_dispatch`).
- `dev-master` verlangt **PHP ≥ 8.3** (NC 35 droppt 8.2) → 8.4 + Anheben des composer-Platform-Pins.

## Verifiziert (lokal, faithful)
`composer require nextcloud/ocp:dev-master` + `php vendor/bin/phpunit` → installiert `dev-master`, **OK (172 tests, 308 assertions)**. Wir sind aktuell mit NC 35-dev kompatibel.

## Nebenbefund
`nextcloud/ocp` hat bereits **v34.0.1** (released 2026-06-18) — **NC 34 ist draußen**, unsere `info.xml` steht aber noch auf `max-version=33`. Genau das, was wir „von außen" mitbekommen wollten. Vorschlag separat: `max-version` auf 34 heben (die Matrix testet es dann automatisch).

Teil von #21.