### PR TITLE
feat: Nextcloud 34 unterstützen (max-version → 34)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -68,7 +68,7 @@ Behalten Sie den Überblick über Arbeitszeiten, Überstunden und Urlaub.
     <screenshot>https://raw.githubusercontent.com/cpcMomentum/worktime/main/screenshots/screenshot-settings.png</screenshot>
 
     <dependencies>
-        <nextcloud min-version="32" max-version="33"/>
+        <nextcloud min-version="32" max-version="34"/>
         <php min-version="8.2"/>
     </dependencies>
 


### PR DESCRIPTION
## Was

`appinfo/info.xml`: `max-version` 33 → **34**. Reiner Kompatibilitäts-Bump, **kein Code-Change**.

## Absicherung
- **Tiefe Breaking-Changes-Recherche** (NC 34 „Hub 26 Spring", 20 Quellen, adversarisch verifiziert): Die harten Breaks in 34 — entfernte `IServerContainer`/`OC\Server`-Accessoren (`getSecureRandom()` etc.) und der jQuery/jQuery-UI-Removal aus dem Core — treffen **nur private/Legacy-Wege**. Diese App ist OCP-only mit DI, kein jQuery, keine `OC_*`-Aufrufe → nicht betroffen.
- **Codebasis geprüft:** keine NC-34-deprecateten APIs genutzt (nur `Util::addScript`/`addStyle`).
- **PHP:** 8.2 bleibt in NC 34 unterstützt (8.3 erst ab NC 35).
- **Tests grün gegen `ocp v34.0.1`** auf PHP **8.2 und 8.4**: `OK (172 tests, 308 assertions)`.

## Demonstration der neuen Automatik
Die `phpunit`-Matrix leitet die NC-Versionen jetzt aus `info.xml` ab — dieser PR triggert daher automatisch zusätzlich die Jobs **`PHP 8.2/8.4 / ocp ^34.0`**. (#21 in Aktion.)

## Ehrliche Einschränkung
Kein Test gegen eine **echte laufende NC-34-Instanz** (lokal läuft NC 33). Basis ist API-Kompatibilität (grüne Stub-Suite gegen ocp v34) + die Breaking-Changes-Analyse. Ein Produktiv-Test-Deploy auf NC 34 bleibt vor dem Release empfehlenswert.