### PR TITLE
feat(overtime): server-side balance guard for payouts (#426)

### DIFF
--- a/lib/Controller/ReportController.php
+++ b/lib/Controller/ReportController.php
@@ -17,6 +17,7 @@ use OCA\WorkTime\Db\TimeEntryMapper;
 use OCA\WorkTime\Service\AbsenceService;
 use OCA\WorkTime\Service\EmployeeService;
 use OCA\WorkTime\Service\HolidayService;
+use OCA\WorkTime\Service\OvertimeCalculationService;
 use OCA\WorkTime\Service\OvertimePayoutService;
 use OCA\WorkTime\Service\PdfService;
 use OCA\WorkTime\Service\PermissionService;
@@ -50,6 +51,7 @@ class ReportController extends BaseController {
         private WorkScheduleService $workScheduleService,
         private YearlyCarryoverService $carryoverService,
         private OvertimePayoutService $payoutService,
+        private OvertimeCalculationService $overtimeCalc,
         private ProjectService $projectService,
         private IL10N $l,
     ) {
@@ -85,7 +87,7 @@ class ReportController extends BaseController {
             $holidays = $this->holidayService->findByMonth($year, $month, $employee->getFederalState());
 
             // Calculate statistics
-            $stats = $this->calculateMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
+            $stats = $this->overtimeCalc->getMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
 
             // Per-day labor-law warnings (#338): minimum break (§4 ArbZG) and max
             // daily hours, evaluated across all entries of each day.
@@ -549,7 +551,7 @@ class ReportController extends BaseController {
             $absences = $this->absenceService->findByEmployeeAndMonth($employeeId, $year, $month);
             $holidays = $this->holidayService->findByMonth($year, $month, $employee->getFederalState());
 
-            $stats = $this->calculateMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
+            $stats = $this->overtimeCalc->getMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
 
             $pdfContent = $this->pdfService->generateMonthlyReport(
                 $employee,
@@ -610,7 +612,7 @@ class ReportController extends BaseController {
             $absences = $this->absenceService->findByEmployeeAndDateRange($employeeId, $start, $end);
             $holidays = $this->holidayService->findHolidaysInRange($start, $end, $employee->getFederalState());
 
-            $stats = $this->calculateRangeStats($employee, $start, $end, $timeEntries, $absences, $holidays);
+            $stats = $this->overtimeCalc->getRangeStats($employee, $start, $end, $timeEntries, $absences, $holidays);
 
             $pdfContent = $this->pdfService->generateRangeReport(
                 $employee,
@@ -662,7 +664,7 @@ class ReportController extends BaseController {
             $absences = $allAbsences[$empId] ?? [];
             $holidays = $this->getHolidaysCached($year, $month, $employee->getFederalState());
 
-            $stats = $this->calculateMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
+            $stats = $this->overtimeCalc->getMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
             $statusSummary = $allStatusSummaries[$empId] ?? ['draft' => 0, 'submitted' => 0, 'approved' => 0, 'rejected' => 0];
 
             $report[] = [
@@ -762,7 +764,7 @@ class ReportController extends BaseController {
                 $absences = $absencesByMonth[$month];
                 $holidays = $this->getHolidaysCached($year, $month, $employee->getFederalState());
 
-                $stats = $this->calculateMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
+                $stats = $this->overtimeCalc->getMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
                 $statusSummary = $allStatusByMonth[$month][$empId] ?? ['draft' => 0, 'submitted' => 0, 'approved' => 0, 'rejected' => 0];
 
                 // Determine dominant status
@@ -859,7 +861,7 @@ class ReportController extends BaseController {
                 $absences = $this->absenceService->findByEmployeeAndMonth($employeeId, $year, $month);
                 $holidays = $this->holidayService->findByMonth($year, $month, $employee->getFederalState());
 
-                $stats = $this->calculateMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
+                $stats = $this->overtimeCalc->getMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
 
                 $monthlyData[] = [
                     'month' => $month,
@@ -967,470 +969,4 @@ class ReportController extends BaseController {
         return $this->workScheduleService->countWorkingDays($absence->getEmployeeId(), $start, $end, []);
     }
 
-    /**
-     * Returns the current date (today, time zeroed). Wrapped in a method so tests
-     * can pin "today" to a fixed date and verify the proportional Soll/overtime logic.
-     */
-    protected function currentDate(): DateTime {
-        return new DateTime('today');
-    }
-
-    /**
-     * Whether the given day has activity that makes it count toward the proportional
-     * Soll: a time entry on that day or an approved absence covering it.
-     *
-     * @param object[] $timeEntries
-     * @param object[] $absences
-     */
-    private function hasActivityOnDay(DateTime $day, array $timeEntries, array $absences): bool {
-        $dayStr = $day->format('Y-m-d');
-        foreach ($timeEntries as $entry) {
-            $entryDate = $entry->getDate();
-            if ($entryDate instanceof DateTime && $entryDate->format('Y-m-d') === $dayStr) {
-                return true;
-            }
-        }
-        foreach ($absences as $absence) {
-            if ($absence->isApproved()
-                && $absence->getStartDate() <= $day
-                && $absence->getEndDate() >= $day) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Statistics for a custom [start, end] range (#102). Unlike the monthly
-     * calculation there is no "until today" proportional logic: a custom-period
-     * timesheet covers a fixed, user-chosen span, so Soll/Ist/Saldo are computed
-     * over the whole range.
-     *
-     * @param TimeEntry[] $timeEntries
-     * @param Absence[] $absences
-     * @param Holiday[] $holidays
-     * @return array<string, mixed>
-     */
-    private function calculateRangeStats(
-        Employee $employee,
-        DateTime $startDate,
-        DateTime $endDate,
-        array $timeEntries,
-        array $absences,
-        array $holidays
-    ): array {
-        $employeeId = $employee->getId();
-
-        // Clip the range to the employment period.
-        $entryDate = $employee->getEntryDate();
-        $exitDate = $employee->getExitDate();
-        if ($entryDate !== null && $startDate < $entryDate) {
-            $startDate = clone $entryDate;
-        }
-        if ($exitDate !== null && $endDate > $exitDate) {
-            $endDate = clone $exitDate;
-        }
-
-        $entryCount = count($timeEntries);
-        if ($startDate > $endDate) {
-            return [
-                'workingDays' => 0, 'holidayCount' => count($holidays),
-                'paidAbsenceDays' => 0, 'targetReductionDays' => 0, 'compensatoryDays' => 0,
-                'absenceDays' => 0, 'adjustedTargetMinutes' => 0, 'actualMinutes' => 0,
-                'overtimeMinutes' => 0, 'entryCount' => $entryCount,
-            ];
-        }
-
-        $workingDays = $this->workScheduleService->countWorkingDays($employeeId, $startDate, $endDate, $holidays);
-        $targetMinutes = $this->workScheduleService->calculateTargetMinutes($employeeId, $startDate, $endDate, $holidays);
-
-        $targetReductionTypes = [\OCA\WorkTime\Db\Absence::TYPE_UNPAID];
-        $overtimeConsumingTypes = [\OCA\WorkTime\Db\Absence::TYPE_COMPENSATORY];
-
-        $paidAbsenceMinutes = 0;
-        $paidAbsenceDays = 0;
-        $targetReductionMinutes = 0;
-        $targetReductionDays = 0;
-        $compensatoryDays = 0;
-
-        foreach ($absences as $absence) {
-            if (!$absence->isApproved()) {
-                continue;
-            }
-            $aStart = $absence->getStartDate() < $startDate ? $startDate : $absence->getStartDate();
-            $aEnd = $absence->getEndDate() > $endDate ? $endDate : $absence->getEndDate();
-            if ($aStart > $aEnd) {
-                continue;
-            }
-            $scope = $absence->getScopeValue();
-            $days = $this->workScheduleService->countWorkingDays($employeeId, $aStart, $aEnd, $holidays) * $scope;
-            $minutes = $this->calculateAbsenceMinutes($employeeId, $aStart, $aEnd, $scope, $holidays);
-
-            if (in_array($absence->getType(), $targetReductionTypes, true)) {
-                $targetReductionDays += $days;
-                $targetReductionMinutes += $minutes;
-            } elseif (in_array($absence->getType(), $overtimeConsumingTypes, true)) {
-                $compensatoryDays += $days;
-            } else {
-                $paidAbsenceDays += $days;
-                $paidAbsenceMinutes += $minutes;
-            }
-        }
-
-        $adjustedTargetMinutes = $targetMinutes - $targetReductionMinutes;
-
-        $workedMinutes = 0;
-        foreach ($timeEntries as $entry) {
-            $workedMinutes += $entry->getWorkMinutes();
-        }
-        $actualMinutes = $workedMinutes + $paidAbsenceMinutes;
-        $overtimeMinutes = $actualMinutes - $adjustedTargetMinutes;
-
-        return [
-            'workingDays' => $workingDays,
-            'holidayCount' => count($holidays),
-            'paidAbsenceDays' => $paidAbsenceDays,
-            'targetReductionDays' => $targetReductionDays,
-            'compensatoryDays' => $compensatoryDays,
-            'absenceDays' => $paidAbsenceDays + $targetReductionDays + $compensatoryDays,
-            'adjustedTargetMinutes' => $adjustedTargetMinutes,
-            'actualMinutes' => $actualMinutes,
-            'overtimeMinutes' => $overtimeMinutes,
-            'entryCount' => $entryCount,
-        ];
-    }
-
-    private function calculateMonthlyStats(
-        Employee $employee,
-        int $year,
-        int $month,
-        array $timeEntries,
-        array $absences,
-        array $holidays
-    ): array {
-        $startDate = new DateTime("$year-$month-01");
-        $monthEndDate = (clone $startDate)->modify('last day of this month');
-        $today = $this->currentDate();
-        $employeeId = $employee->getId();
-
-        // Clip to employee's employment period
-        $entryDate = $employee->getEntryDate();
-        $exitDate = $employee->getExitDate();
-
-        // Month entirely before employment start → return zeros
-        if ($entryDate !== null && $monthEndDate < $entryDate) {
-            return $this->zeroMonthStats(workingDaysOverride: 0);
-        }
-
-        // Month entirely after employment end → return zeros
-        if ($exitDate !== null && $startDate > $exitDate) {
-            return $this->zeroMonthStats(workingDaysOverride: 0);
-        }
-
-        // Clip start/end to employment period
-        if ($entryDate !== null && $startDate < $entryDate) {
-            $startDate = clone $entryDate;
-        }
-        if ($exitDate !== null && $monthEndDate > $exitDate) {
-            $monthEndDate = clone $exitDate;
-        }
-
-        // Determine if this is a future month (hasn't started yet)
-        $isFutureMonth = $startDate > $today;
-
-        // For future months: return zeros for Soll/Ist/Überstunden
-        if ($isFutureMonth) {
-            $workingDaysMonth = $this->workScheduleService->countWorkingDays($employeeId, $startDate, $monthEndDate, $holidays);
-            $monthlyTargetMinutes = $this->workScheduleService->calculateTargetMinutes($employeeId, $startDate, $monthEndDate, $holidays);
-
-            // Count planned absences for display only
-            $absenceDaysMonth = 0;
-            foreach ($absences as $absence) {
-                if ($absence->isApproved()) {
-                    $absenceStart = $absence->getStartDate() < $startDate ? $startDate : $absence->getStartDate();
-                    $absenceEnd = $absence->getEndDate() > $monthEndDate ? $monthEndDate : $absence->getEndDate();
-                    $absenceDaysMonth += $this->workScheduleService->countWorkingDays($employeeId, $absenceStart, $absenceEnd, $holidays);
-                }
-            }
-
-            // dailyMinutes approximation for display
-            $dailyMinutes = $workingDaysMonth > 0 ? (int)round($monthlyTargetMinutes / $workingDaysMonth) : 0;
-
-            return [
-                'workingDays' => $workingDaysMonth,
-                'workingDaysMonth' => $workingDaysMonth,
-                'workingDaysUntilToday' => 0,
-                'holidayCount' => count($holidays),
-                'paidAbsenceDays' => $absenceDaysMonth,
-                'targetReductionDays' => 0,
-                'compensatoryDays' => 0,
-                'absenceDays' => $absenceDaysMonth,
-                'dailyMinutes' => $dailyMinutes,
-                'targetMinutes' => 0,
-                'monthlyTargetMinutes' => 0,
-                'adjustedTargetMinutes' => 0,
-                'adjustedMonthlyTargetMinutes' => 0,
-                'workedMinutes' => 0,
-                'workedHours' => 0,
-                'paidAbsenceMinutes' => 0,
-                'paidAbsenceHours' => 0,
-                'actualMinutes' => 0,
-                'actualHours' => 0,
-                'overtimeMinutes' => 0,
-                'overtimeHours' => 0,
-                'entryCount' => 0,
-                'isFutureMonth' => true,
-            ];
-        }
-
-        // Determine if this is the current month
-        $isCurrentMonth = $year === (int)$today->format('Y') && $month === (int)$today->format('n');
-
-        // For "up to today" calculations.
-        // The running day only counts toward the proportional Soll once it has activity
-        // (a time entry today or an approved absence covering today). Without that,
-        // today is excluded so the balance shows no spurious morning deficit.
-        $endDateForActual = $monthEndDate;
-        if ($isCurrentMonth && $today < $monthEndDate) {
-            $endDateForActual = $this->hasActivityOnDay($today, $timeEntries, $absences)
-                ? $today
-                : (clone $today)->modify('-1 day');
-        }
-
-        // If today is excluded and it is the first (working) day of the month, the
-        // "until today" range falls before the month start -> no proportional Soll yet.
-        $hasProportionalRange = $endDateForActual >= $startDate;
-
-        // Count working days using schedule-aware service
-        $workingDaysMonth = $this->workScheduleService->countWorkingDays($employeeId, $startDate, $monthEndDate, $holidays);
-        $workingDaysUntilToday = $hasProportionalRange
-            ? $this->workScheduleService->countWorkingDays($employeeId, $startDate, $endDateForActual, $holidays)
-            : 0.0;
-
-        // Calculate target minutes using schedule-aware service
-        $monthlyTargetMinutes = $this->workScheduleService->calculateTargetMinutes($employeeId, $startDate, $monthEndDate, $holidays);
-        $proportionalTargetMinutes = $hasProportionalRange
-            ? $this->workScheduleService->calculateTargetMinutes($employeeId, $startDate, $endDateForActual, $holidays)
-            : 0;
-
-        // dailyMinutes approximation for display
-        $dailyMinutes = $workingDaysMonth > 0 ? (int)round($monthlyTargetMinutes / $workingDaysMonth) : 0;
-
-        // Process absences: paid (credit Ist) vs. target-reducing (Soll) vs. compensatory.
-        $paidAbsenceMinutesMonth = 0;
-        $paidAbsenceDaysMonth = 0;
-        $targetReductionMinutesMonth = 0;
-        $targetReductionDaysMonth = 0;
-        $compensatoryDaysMonth = 0;
-
-        $paidAbsenceMinutesUntilToday = 0;
-        $paidAbsenceDaysUntilToday = 0;
-        $targetReductionMinutesUntilToday = 0;
-        $targetReductionDaysUntilToday = 0;
-        $compensatoryDaysUntilToday = 0;
-
-        // Types that reduce the target (Soll) instead of crediting work time (Ist).
-        $targetReductionTypes = [
-            \OCA\WorkTime\Db\Absence::TYPE_UNPAID,
-        ];
-
-        // Compensatory time (Freizeitausgleich) is neither credited to the Ist nor
-        // deducted from the Soll: the day stays a target day with no work credited, so
-        // the overtime balance drops by one daily target when FZA is taken (#149, #186).
-        $overtimeConsumingTypes = [
-            \OCA\WorkTime\Db\Absence::TYPE_COMPENSATORY,
-        ];
-
-        foreach ($absences as $absence) {
-            if ($absence->isApproved()) {
-                $absenceStart = $absence->getStartDate();
-                $absenceEnd = $absence->getEndDate();
-                $absenceScope = $absence->getScopeValue();
-
-                // For full month display
-                if ($absenceStart <= $monthEndDate) {
-                    $monthAbsenceStart = $absenceStart < $startDate ? $startDate : $absenceStart;
-                    $monthAbsenceEnd = $absenceEnd > $monthEndDate ? $monthEndDate : $absenceEnd;
-                    $daysInMonth = $this->workScheduleService->countWorkingDays($employeeId, $monthAbsenceStart, $monthAbsenceEnd, $holidays);
-                    $effectiveDays = $daysInMonth * $absenceScope;
-
-                    // Calculate absence minutes per day using actual schedule
-                    $absenceMinutes = $this->calculateAbsenceMinutes($employeeId, $monthAbsenceStart, $monthAbsenceEnd, $absenceScope, $holidays);
-
-                    if (in_array($absence->getType(), $targetReductionTypes, true)) {
-                        $targetReductionDaysMonth += $effectiveDays;
-                        $targetReductionMinutesMonth += $absenceMinutes;
-                    } elseif (in_array($absence->getType(), $overtimeConsumingTypes, true)) {
-                        // FZA: counted as an absence day, but not credited to the Ist.
-                        $compensatoryDaysMonth += $effectiveDays;
-                    } else {
-                        $paidAbsenceDaysMonth += $effectiveDays;
-                        $paidAbsenceMinutesMonth += $absenceMinutes;
-                    }
-                }
-
-                // For actual/overtime calculation: only count absences up to today
-                if ($hasProportionalRange && $absenceStart <= $endDateForActual) {
-                    $actualAbsenceStart = $absenceStart < $startDate ? $startDate : $absenceStart;
-                    $actualAbsenceEnd = $absenceEnd > $endDateForActual ? $endDateForActual : $absenceEnd;
-                    $daysUntilToday = $this->workScheduleService->countWorkingDays($employeeId, $actualAbsenceStart, $actualAbsenceEnd, $holidays);
-                    $effectiveDaysUntilToday = $daysUntilToday * $absenceScope;
-
-                    $absenceMinutesUntilToday = $this->calculateAbsenceMinutes($employeeId, $actualAbsenceStart, $actualAbsenceEnd, $absenceScope, $holidays);
-
-                    if (in_array($absence->getType(), $targetReductionTypes, true)) {
-                        $targetReductionDaysUntilToday += $effectiveDaysUntilToday;
-                        $targetReductionMinutesUntilToday += $absenceMinutesUntilToday;
-                    } elseif (in_array($absence->getType(), $overtimeConsumingTypes, true)) {
-                        // FZA: not credited to the Ist -> overtime decreases by the daily target.
-                        $compensatoryDaysUntilToday += $effectiveDaysUntilToday;
-                    } else {
-                        $paidAbsenceDaysUntilToday += $effectiveDaysUntilToday;
-                        $paidAbsenceMinutesUntilToday += $absenceMinutesUntilToday;
-                    }
-                }
-            }
-        }
-
-        // Adjust targets for unpaid leave (compensatory time deliberately keeps the target).
-        $adjustedMonthlyTargetMinutes = $monthlyTargetMinutes - $targetReductionMinutesMonth;
-        $adjustedProportionalTargetMinutes = $proportionalTargetMinutes - $targetReductionMinutesUntilToday;
-
-        // Sum actual work minutes from time entries
-        $workedMinutes = 0;
-        foreach ($timeEntries as $entry) {
-            $workedMinutes += $entry->getWorkMinutes();
-        }
-
-        // Effective actual = worked + paid absences (up to today)
-        $actualMinutes = $workedMinutes + $paidAbsenceMinutesUntilToday;
-
-        // Calculate overtime against proportional target (not full month)
-        $overtimeMinutes = $actualMinutes - $adjustedProportionalTargetMinutes;
-
-        return [
-            // Full month values (for display in Monatsübersicht)
-            'workingDays' => $workingDaysMonth,
-            'workingDaysMonth' => $workingDaysMonth,
-            'workingDaysUntilToday' => $workingDaysUntilToday,
-            'holidayCount' => count($holidays),
-            'paidAbsenceDays' => $paidAbsenceDaysMonth,
-            'targetReductionDays' => $targetReductionDaysMonth,  // Unpaid leave
-            'compensatoryDays' => $compensatoryDaysMonth,
-            'absenceDays' => $paidAbsenceDaysMonth + $targetReductionDaysMonth + $compensatoryDaysMonth,
-            'dailyMinutes' => $dailyMinutes,
-
-            // Target values
-            'targetMinutes' => $adjustedMonthlyTargetMinutes,
-            'monthlyTargetMinutes' => $monthlyTargetMinutes,
-            'adjustedTargetMinutes' => $adjustedProportionalTargetMinutes,
-            'adjustedMonthlyTargetMinutes' => $adjustedMonthlyTargetMinutes,
-
-            // Actual values (up to today)
-            'workedMinutes' => $workedMinutes,
-            'workedHours' => round($workedMinutes / 60, 2),
-            'paidAbsenceMinutes' => $paidAbsenceMinutesUntilToday,
-            'paidAbsenceHours' => round($paidAbsenceMinutesUntilToday / 60, 2),
-            'actualMinutes' => $actualMinutes,
-            'actualHours' => round($actualMinutes / 60, 2),
-
-            // Overtime (proportional)
-            'overtimeMinutes' => $overtimeMinutes,
-            'overtimeHours' => round($overtimeMinutes / 60, 2),
-            'entryCount' => count($timeEntries),
-            'isFutureMonth' => false,
-        ];
-    }
-
-    private function zeroMonthStats(int $workingDaysOverride = 0): array {
-        return [
-            'workingDays' => $workingDaysOverride,
-            'workingDaysMonth' => $workingDaysOverride,
-            'workingDaysUntilToday' => 0,
-            'holidayCount' => 0,
-            'paidAbsenceDays' => 0,
-            'targetReductionDays' => 0,
-            'compensatoryDays' => 0,
-            'absenceDays' => 0,
-            'dailyMinutes' => 0,
-            'targetMinutes' => 0,
-            'monthlyTargetMinutes' => 0,
-            'adjustedTargetMinutes' => 0,
-            'adjustedMonthlyTargetMinutes' => 0,
-            'workedMinutes' => 0,
-            'workedHours' => 0,
-            'paidAbsenceMinutes' => 0,
-            'paidAbsenceHours' => 0,
-            'actualMinutes' => 0,
-            'actualHours' => 0,
-            'overtimeMinutes' => 0,
-            'overtimeHours' => 0,
-            'entryCount' => 0,
-            'isFutureMonth' => false,
-        ];
-    }
-
-    /**
-     * Calculate absence minutes using actual schedule for each day.
-     */
-    private function calculateAbsenceMinutes(int $employeeId, DateTime $start, DateTime $end, float $scope, array $holidays): int {
-        $holidayMap = [];
-        foreach ($holidays as $holiday) {
-            $holidayMap[$holiday->getDate()->format('Y-m-d')] = $holiday;
-        }
-
-        $totalMinutes = 0;
-        $current = clone $start;
-        while ($current <= $end) {
-            $dateStr = $current->format('Y-m-d');
-            $dayMinutes = $this->workScheduleService->getDailyMinutesForDate($employeeId, $current);
-
-            if ($dayMinutes > 0 && !isset($holidayMap[$dateStr])) {
-                $totalMinutes += (int)round($dayMinutes * $scope);
-            }
-            $current->modify('+1 day');
-        }
-
-        return $totalMinutes;
-    }
-
-    /**
-     * Count working days (Mon-Fri) excluding holidays
-     * Holiday scope determines how much of the day is free:
-     * - scope = 1.0: full holiday = 0 working days
-     * - scope = 0.5: half holiday = 0.5 working days remaining
-     */
-    private function countWorkingDays(DateTime $startDate, DateTime $endDate, array $holidays): float {
-        // Build holiday lookup: date => Holiday object
-        $holidayMap = [];
-        foreach ($holidays as $holiday) {
-            $holidayMap[$holiday->getDate()->format('Y-m-d')] = $holiday;
-        }
-
-        $workingDays = 0.0;
-        $current = clone $startDate;
-
-        while ($current <= $endDate) {
-            $dayOfWeek = (int)$current->format('N');
-            $dateStr = $current->format('Y-m-d');
-
-            // Only count Monday-Friday
-            if ($dayOfWeek < 6) {
-                if (isset($holidayMap[$dateStr])) {
-                    // Holiday exists - add remaining working portion
-                    // scope = 1.0 (full holiday) → 0 working days
-                    // scope = 0.5 (half holiday) → 0.5 working days
-                    $holiday = $holidayMap[$dateStr];
-                    $workingDays += (1.0 - $holiday->getScopeValue());
-                } else {
-                    // Regular working day
-                    $workingDays += 1.0;
-                }
-            }
-
-            $current->modify('+1 day');
-        }
-
-        return $workingDays;
-    }
 }

--- a/lib/Service/OvertimeCalculationService.php
+++ b/lib/Service/OvertimeCalculationService.php
@@ -12,7 +12,9 @@ namespace OCA\WorkTime\Service;
 use DateTime;
 use OCA\WorkTime\Db\Absence;
 use OCA\WorkTime\Db\Employee;
+use OCA\WorkTime\Db\Holiday;
 use OCA\WorkTime\Db\OvertimePayoutMapper;
+use OCA\WorkTime\Db\TimeEntry;
 
 /**
  * Overtime / monthly-statistics engine (#426).
@@ -84,8 +86,8 @@ class OvertimeCalculationService {
      * Whether the given day has activity that makes it count toward the proportional
      * Soll: a time entry on that day or an approved absence covering it.
      *
-     * @param object[] $timeEntries
-     * @param object[] $absences
+     * @param TimeEntry[] $timeEntries
+     * @param Absence[] $absences
      */
     private function hasActivityOnDay(DateTime $day, array $timeEntries, array $absences): bool {
         $dayStr = $day->format('Y-m-d');
@@ -111,9 +113,9 @@ class OvertimeCalculationService {
      * timesheet covers a fixed, user-chosen span, so Soll/Ist/Saldo are computed
      * over the whole range.
      *
-     * @param object[] $timeEntries
-     * @param object[] $absences
-     * @param object[] $holidays
+     * @param TimeEntry[] $timeEntries
+     * @param Absence[] $absences
+     * @param Holiday[] $holidays
      * @return array<string, mixed>
      */
     public function getRangeStats(
@@ -206,9 +208,9 @@ class OvertimeCalculationService {
     }
 
     /**
-     * @param object[] $timeEntries
-     * @param object[] $absences
-     * @param object[] $holidays
+     * @param TimeEntry[] $timeEntries
+     * @param Absence[] $absences
+     * @param Holiday[] $holidays
      * @return array<string, mixed>
      */
     public function getMonthlyStats(
@@ -487,7 +489,7 @@ class OvertimeCalculationService {
     /**
      * Calculate absence minutes using actual schedule for each day.
      *
-     * @param object[] $holidays
+     * @param Holiday[] $holidays
      */
     private function calculateAbsenceMinutes(int $employeeId, DateTime $start, DateTime $end, float $scope, array $holidays): int {
         $holidayMap = [];

--- a/lib/Service/OvertimeCalculationService.php
+++ b/lib/Service/OvertimeCalculationService.php
@@ -1,0 +1,512 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Axel Deffner <axel@cpcmomentum.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Service;
+
+use DateTime;
+use OCA\WorkTime\Db\Absence;
+use OCA\WorkTime\Db\Employee;
+use OCA\WorkTime\Db\OvertimePayoutMapper;
+
+/**
+ * Overtime / monthly-statistics engine (#426).
+ *
+ * Holds the Soll/Ist/overtime calculation that previously lived private in
+ * ReportController. Extracted so the net overtime balance can be reused outside
+ * the report endpoints — notably the server-side payout guard in
+ * OvertimePayoutService::create().
+ *
+ * Depends only on lower-level services and the payout mapper (never the payout
+ * service) so it can be injected into OvertimePayoutService without a cycle.
+ */
+class OvertimeCalculationService {
+
+    public function __construct(
+        private WorkScheduleService $workScheduleService,
+        private YearlyCarryoverService $carryoverService,
+        private OvertimePayoutMapper $payoutMapper,
+        private EmployeeService $employeeService,
+        private TimeEntryService $timeEntryService,
+        private AbsenceService $absenceService,
+        private HolidayService $holidayService,
+    ) {
+    }
+
+    /**
+     * Net overtime balance for an employee in a given year, in minutes:
+     * sum of the monthly proportional overtime + carryover from previous years
+     * − overtime already paid out in money (#401).
+     *
+     * This is the authoritative balance used by the payout guard: a new payout
+     * of X minutes is only permissible while X does not exceed this value.
+     */
+    public function getNetOvertimeMinutes(int $employeeId, int $year): int {
+        $employee = $this->employeeService->find($employeeId);
+
+        $totalOvertime = 0;
+        for ($month = 1; $month <= 12; $month++) {
+            $startDate = new DateTime("$year-$month-01");
+
+            // Skip future months (no overtime accrued yet).
+            if ($startDate > $this->currentDate()) {
+                break;
+            }
+
+            $timeEntries = $this->timeEntryService->findByEmployeeAndMonth($employeeId, $year, $month);
+            $absences = $this->absenceService->findByEmployeeAndMonth($employeeId, $year, $month);
+            $holidays = $this->holidayService->findByMonth($year, $month, $employee->getFederalState());
+
+            $stats = $this->getMonthlyStats($employee, $year, $month, $timeEntries, $absences, $holidays);
+            $totalOvertime += $stats['overtimeMinutes'];
+        }
+
+        $carryoverMinutes = $this->carryoverService->getOvertimeCarryoverMinutes($employeeId, $year);
+        $paidOutMinutes = $this->payoutMapper->sumMinutesByEmployeeAndYear($employeeId, $year);
+
+        return $totalOvertime + $carryoverMinutes - $paidOutMinutes;
+    }
+
+    /**
+     * Returns the current date (today, time zeroed). Wrapped in a method so tests
+     * can pin "today" to a fixed date and verify the proportional Soll/overtime logic.
+     */
+    protected function currentDate(): DateTime {
+        return new DateTime('today');
+    }
+
+    /**
+     * Whether the given day has activity that makes it count toward the proportional
+     * Soll: a time entry on that day or an approved absence covering it.
+     *
+     * @param object[] $timeEntries
+     * @param object[] $absences
+     */
+    private function hasActivityOnDay(DateTime $day, array $timeEntries, array $absences): bool {
+        $dayStr = $day->format('Y-m-d');
+        foreach ($timeEntries as $entry) {
+            $entryDate = $entry->getDate();
+            if ($entryDate instanceof DateTime && $entryDate->format('Y-m-d') === $dayStr) {
+                return true;
+            }
+        }
+        foreach ($absences as $absence) {
+            if ($absence->isApproved()
+                && $absence->getStartDate() <= $day
+                && $absence->getEndDate() >= $day) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Statistics for a custom [start, end] range (#102). Unlike the monthly
+     * calculation there is no "until today" proportional logic: a custom-period
+     * timesheet covers a fixed, user-chosen span, so Soll/Ist/Saldo are computed
+     * over the whole range.
+     *
+     * @param object[] $timeEntries
+     * @param object[] $absences
+     * @param object[] $holidays
+     * @return array<string, mixed>
+     */
+    public function getRangeStats(
+        Employee $employee,
+        DateTime $startDate,
+        DateTime $endDate,
+        array $timeEntries,
+        array $absences,
+        array $holidays
+    ): array {
+        $employeeId = $employee->getId();
+
+        // Clip the range to the employment period.
+        $entryDate = $employee->getEntryDate();
+        $exitDate = $employee->getExitDate();
+        if ($entryDate !== null && $startDate < $entryDate) {
+            $startDate = clone $entryDate;
+        }
+        if ($exitDate !== null && $endDate > $exitDate) {
+            $endDate = clone $exitDate;
+        }
+
+        $entryCount = count($timeEntries);
+        if ($startDate > $endDate) {
+            return [
+                'workingDays' => 0, 'holidayCount' => count($holidays),
+                'paidAbsenceDays' => 0, 'targetReductionDays' => 0, 'compensatoryDays' => 0,
+                'absenceDays' => 0, 'adjustedTargetMinutes' => 0, 'actualMinutes' => 0,
+                'overtimeMinutes' => 0, 'entryCount' => $entryCount,
+            ];
+        }
+
+        $workingDays = $this->workScheduleService->countWorkingDays($employeeId, $startDate, $endDate, $holidays);
+        $targetMinutes = $this->workScheduleService->calculateTargetMinutes($employeeId, $startDate, $endDate, $holidays);
+
+        $targetReductionTypes = [Absence::TYPE_UNPAID];
+        $overtimeConsumingTypes = [Absence::TYPE_COMPENSATORY];
+
+        $paidAbsenceMinutes = 0;
+        $paidAbsenceDays = 0;
+        $targetReductionMinutes = 0;
+        $targetReductionDays = 0;
+        $compensatoryDays = 0;
+
+        foreach ($absences as $absence) {
+            if (!$absence->isApproved()) {
+                continue;
+            }
+            $aStart = $absence->getStartDate() < $startDate ? $startDate : $absence->getStartDate();
+            $aEnd = $absence->getEndDate() > $endDate ? $endDate : $absence->getEndDate();
+            if ($aStart > $aEnd) {
+                continue;
+            }
+            $scope = $absence->getScopeValue();
+            $days = $this->workScheduleService->countWorkingDays($employeeId, $aStart, $aEnd, $holidays) * $scope;
+            $minutes = $this->calculateAbsenceMinutes($employeeId, $aStart, $aEnd, $scope, $holidays);
+
+            if (in_array($absence->getType(), $targetReductionTypes, true)) {
+                $targetReductionDays += $days;
+                $targetReductionMinutes += $minutes;
+            } elseif (in_array($absence->getType(), $overtimeConsumingTypes, true)) {
+                $compensatoryDays += $days;
+            } else {
+                $paidAbsenceDays += $days;
+                $paidAbsenceMinutes += $minutes;
+            }
+        }
+
+        $adjustedTargetMinutes = $targetMinutes - $targetReductionMinutes;
+
+        $workedMinutes = 0;
+        foreach ($timeEntries as $entry) {
+            $workedMinutes += $entry->getWorkMinutes();
+        }
+        $actualMinutes = $workedMinutes + $paidAbsenceMinutes;
+        $overtimeMinutes = $actualMinutes - $adjustedTargetMinutes;
+
+        return [
+            'workingDays' => $workingDays,
+            'holidayCount' => count($holidays),
+            'paidAbsenceDays' => $paidAbsenceDays,
+            'targetReductionDays' => $targetReductionDays,
+            'compensatoryDays' => $compensatoryDays,
+            'absenceDays' => $paidAbsenceDays + $targetReductionDays + $compensatoryDays,
+            'adjustedTargetMinutes' => $adjustedTargetMinutes,
+            'actualMinutes' => $actualMinutes,
+            'overtimeMinutes' => $overtimeMinutes,
+            'entryCount' => $entryCount,
+        ];
+    }
+
+    /**
+     * @param object[] $timeEntries
+     * @param object[] $absences
+     * @param object[] $holidays
+     * @return array<string, mixed>
+     */
+    public function getMonthlyStats(
+        Employee $employee,
+        int $year,
+        int $month,
+        array $timeEntries,
+        array $absences,
+        array $holidays
+    ): array {
+        $startDate = new DateTime("$year-$month-01");
+        $monthEndDate = (clone $startDate)->modify('last day of this month');
+        $today = $this->currentDate();
+        $employeeId = $employee->getId();
+
+        // Clip to employee's employment period
+        $entryDate = $employee->getEntryDate();
+        $exitDate = $employee->getExitDate();
+
+        // Month entirely before employment start → return zeros
+        if ($entryDate !== null && $monthEndDate < $entryDate) {
+            return $this->zeroMonthStats(workingDaysOverride: 0);
+        }
+
+        // Month entirely after employment end → return zeros
+        if ($exitDate !== null && $startDate > $exitDate) {
+            return $this->zeroMonthStats(workingDaysOverride: 0);
+        }
+
+        // Clip start/end to employment period
+        if ($entryDate !== null && $startDate < $entryDate) {
+            $startDate = clone $entryDate;
+        }
+        if ($exitDate !== null && $monthEndDate > $exitDate) {
+            $monthEndDate = clone $exitDate;
+        }
+
+        // Determine if this is a future month (hasn't started yet)
+        $isFutureMonth = $startDate > $today;
+
+        // For future months: return zeros for Soll/Ist/Überstunden
+        if ($isFutureMonth) {
+            $workingDaysMonth = $this->workScheduleService->countWorkingDays($employeeId, $startDate, $monthEndDate, $holidays);
+            $monthlyTargetMinutes = $this->workScheduleService->calculateTargetMinutes($employeeId, $startDate, $monthEndDate, $holidays);
+
+            // Count planned absences for display only
+            $absenceDaysMonth = 0;
+            foreach ($absences as $absence) {
+                if ($absence->isApproved()) {
+                    $absenceStart = $absence->getStartDate() < $startDate ? $startDate : $absence->getStartDate();
+                    $absenceEnd = $absence->getEndDate() > $monthEndDate ? $monthEndDate : $absence->getEndDate();
+                    $absenceDaysMonth += $this->workScheduleService->countWorkingDays($employeeId, $absenceStart, $absenceEnd, $holidays);
+                }
+            }
+
+            // dailyMinutes approximation for display
+            $dailyMinutes = $workingDaysMonth > 0 ? (int)round($monthlyTargetMinutes / $workingDaysMonth) : 0;
+
+            return [
+                'workingDays' => $workingDaysMonth,
+                'workingDaysMonth' => $workingDaysMonth,
+                'workingDaysUntilToday' => 0,
+                'holidayCount' => count($holidays),
+                'paidAbsenceDays' => $absenceDaysMonth,
+                'targetReductionDays' => 0,
+                'compensatoryDays' => 0,
+                'absenceDays' => $absenceDaysMonth,
+                'dailyMinutes' => $dailyMinutes,
+                'targetMinutes' => 0,
+                'monthlyTargetMinutes' => 0,
+                'adjustedTargetMinutes' => 0,
+                'adjustedMonthlyTargetMinutes' => 0,
+                'workedMinutes' => 0,
+                'workedHours' => 0,
+                'paidAbsenceMinutes' => 0,
+                'paidAbsenceHours' => 0,
+                'actualMinutes' => 0,
+                'actualHours' => 0,
+                'overtimeMinutes' => 0,
+                'overtimeHours' => 0,
+                'entryCount' => 0,
+                'isFutureMonth' => true,
+            ];
+        }
+
+        // Determine if this is the current month
+        $isCurrentMonth = $year === (int)$today->format('Y') && $month === (int)$today->format('n');
+
+        // For "up to today" calculations.
+        // The running day only counts toward the proportional Soll once it has activity
+        // (a time entry today or an approved absence covering today). Without that,
+        // today is excluded so the balance shows no spurious morning deficit.
+        $endDateForActual = $monthEndDate;
+        if ($isCurrentMonth && $today < $monthEndDate) {
+            $endDateForActual = $this->hasActivityOnDay($today, $timeEntries, $absences)
+                ? $today
+                : (clone $today)->modify('-1 day');
+        }
+
+        // If today is excluded and it is the first (working) day of the month, the
+        // "until today" range falls before the month start -> no proportional Soll yet.
+        $hasProportionalRange = $endDateForActual >= $startDate;
+
+        // Count working days using schedule-aware service
+        $workingDaysMonth = $this->workScheduleService->countWorkingDays($employeeId, $startDate, $monthEndDate, $holidays);
+        $workingDaysUntilToday = $hasProportionalRange
+            ? $this->workScheduleService->countWorkingDays($employeeId, $startDate, $endDateForActual, $holidays)
+            : 0.0;
+
+        // Calculate target minutes using schedule-aware service
+        $monthlyTargetMinutes = $this->workScheduleService->calculateTargetMinutes($employeeId, $startDate, $monthEndDate, $holidays);
+        $proportionalTargetMinutes = $hasProportionalRange
+            ? $this->workScheduleService->calculateTargetMinutes($employeeId, $startDate, $endDateForActual, $holidays)
+            : 0;
+
+        // dailyMinutes approximation for display
+        $dailyMinutes = $workingDaysMonth > 0 ? (int)round($monthlyTargetMinutes / $workingDaysMonth) : 0;
+
+        // Process absences: paid (credit Ist) vs. target-reducing (Soll) vs. compensatory.
+        $paidAbsenceMinutesMonth = 0;
+        $paidAbsenceDaysMonth = 0;
+        $targetReductionMinutesMonth = 0;
+        $targetReductionDaysMonth = 0;
+        $compensatoryDaysMonth = 0;
+
+        $paidAbsenceMinutesUntilToday = 0;
+        $paidAbsenceDaysUntilToday = 0;
+        $targetReductionMinutesUntilToday = 0;
+        $targetReductionDaysUntilToday = 0;
+        $compensatoryDaysUntilToday = 0;
+
+        // Types that reduce the target (Soll) instead of crediting work time (Ist).
+        $targetReductionTypes = [
+            Absence::TYPE_UNPAID,
+        ];
+
+        // Compensatory time (Freizeitausgleich) is neither credited to the Ist nor
+        // deducted from the Soll: the day stays a target day with no work credited, so
+        // the overtime balance drops by one daily target when FZA is taken (#149, #186).
+        $overtimeConsumingTypes = [
+            Absence::TYPE_COMPENSATORY,
+        ];
+
+        foreach ($absences as $absence) {
+            if ($absence->isApproved()) {
+                $absenceStart = $absence->getStartDate();
+                $absenceEnd = $absence->getEndDate();
+                $absenceScope = $absence->getScopeValue();
+
+                // For full month display
+                if ($absenceStart <= $monthEndDate) {
+                    $monthAbsenceStart = $absenceStart < $startDate ? $startDate : $absenceStart;
+                    $monthAbsenceEnd = $absenceEnd > $monthEndDate ? $monthEndDate : $absenceEnd;
+                    $daysInMonth = $this->workScheduleService->countWorkingDays($employeeId, $monthAbsenceStart, $monthAbsenceEnd, $holidays);
+                    $effectiveDays = $daysInMonth * $absenceScope;
+
+                    // Calculate absence minutes per day using actual schedule
+                    $absenceMinutes = $this->calculateAbsenceMinutes($employeeId, $monthAbsenceStart, $monthAbsenceEnd, $absenceScope, $holidays);
+
+                    if (in_array($absence->getType(), $targetReductionTypes, true)) {
+                        $targetReductionDaysMonth += $effectiveDays;
+                        $targetReductionMinutesMonth += $absenceMinutes;
+                    } elseif (in_array($absence->getType(), $overtimeConsumingTypes, true)) {
+                        // FZA: counted as an absence day, but not credited to the Ist.
+                        $compensatoryDaysMonth += $effectiveDays;
+                    } else {
+                        $paidAbsenceDaysMonth += $effectiveDays;
+                        $paidAbsenceMinutesMonth += $absenceMinutes;
+                    }
+                }
+
+                // For actual/overtime calculation: only count absences up to today
+                if ($hasProportionalRange && $absenceStart <= $endDateForActual) {
+                    $actualAbsenceStart = $absenceStart < $startDate ? $startDate : $absenceStart;
+                    $actualAbsenceEnd = $absenceEnd > $endDateForActual ? $endDateForActual : $absenceEnd;
+                    $daysUntilToday = $this->workScheduleService->countWorkingDays($employeeId, $actualAbsenceStart, $actualAbsenceEnd, $holidays);
+                    $effectiveDaysUntilToday = $daysUntilToday * $absenceScope;
+
+                    $absenceMinutesUntilToday = $this->calculateAbsenceMinutes($employeeId, $actualAbsenceStart, $actualAbsenceEnd, $absenceScope, $holidays);
+
+                    if (in_array($absence->getType(), $targetReductionTypes, true)) {
+                        $targetReductionDaysUntilToday += $effectiveDaysUntilToday;
+                        $targetReductionMinutesUntilToday += $absenceMinutesUntilToday;
+                    } elseif (in_array($absence->getType(), $overtimeConsumingTypes, true)) {
+                        // FZA: not credited to the Ist -> overtime decreases by the daily target.
+                        $compensatoryDaysUntilToday += $effectiveDaysUntilToday;
+                    } else {
+                        $paidAbsenceDaysUntilToday += $effectiveDaysUntilToday;
+                        $paidAbsenceMinutesUntilToday += $absenceMinutesUntilToday;
+                    }
+                }
+            }
+        }
+
+        // Adjust targets for unpaid leave (compensatory time deliberately keeps the target).
+        $adjustedMonthlyTargetMinutes = $monthlyTargetMinutes - $targetReductionMinutesMonth;
+        $adjustedProportionalTargetMinutes = $proportionalTargetMinutes - $targetReductionMinutesUntilToday;
+
+        // Sum actual work minutes from time entries
+        $workedMinutes = 0;
+        foreach ($timeEntries as $entry) {
+            $workedMinutes += $entry->getWorkMinutes();
+        }
+
+        // Effective actual = worked + paid absences (up to today)
+        $actualMinutes = $workedMinutes + $paidAbsenceMinutesUntilToday;
+
+        // Calculate overtime against proportional target (not full month)
+        $overtimeMinutes = $actualMinutes - $adjustedProportionalTargetMinutes;
+
+        return [
+            // Full month values (for display in Monatsübersicht)
+            'workingDays' => $workingDaysMonth,
+            'workingDaysMonth' => $workingDaysMonth,
+            'workingDaysUntilToday' => $workingDaysUntilToday,
+            'holidayCount' => count($holidays),
+            'paidAbsenceDays' => $paidAbsenceDaysMonth,
+            'targetReductionDays' => $targetReductionDaysMonth,  // Unpaid leave
+            'compensatoryDays' => $compensatoryDaysMonth,
+            'absenceDays' => $paidAbsenceDaysMonth + $targetReductionDaysMonth + $compensatoryDaysMonth,
+            'dailyMinutes' => $dailyMinutes,
+
+            // Target values
+            'targetMinutes' => $adjustedMonthlyTargetMinutes,
+            'monthlyTargetMinutes' => $monthlyTargetMinutes,
+            'adjustedTargetMinutes' => $adjustedProportionalTargetMinutes,
+            'adjustedMonthlyTargetMinutes' => $adjustedMonthlyTargetMinutes,
+
+            // Actual values (up to today)
+            'workedMinutes' => $workedMinutes,
+            'workedHours' => round($workedMinutes / 60, 2),
+            'paidAbsenceMinutes' => $paidAbsenceMinutesUntilToday,
+            'paidAbsenceHours' => round($paidAbsenceMinutesUntilToday / 60, 2),
+            'actualMinutes' => $actualMinutes,
+            'actualHours' => round($actualMinutes / 60, 2),
+
+            // Overtime (proportional)
+            'overtimeMinutes' => $overtimeMinutes,
+            'overtimeHours' => round($overtimeMinutes / 60, 2),
+            'entryCount' => count($timeEntries),
+            'isFutureMonth' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function zeroMonthStats(int $workingDaysOverride = 0): array {
+        return [
+            'workingDays' => $workingDaysOverride,
+            'workingDaysMonth' => $workingDaysOverride,
+            'workingDaysUntilToday' => 0,
+            'holidayCount' => 0,
+            'paidAbsenceDays' => 0,
+            'targetReductionDays' => 0,
+            'compensatoryDays' => 0,
+            'absenceDays' => 0,
+            'dailyMinutes' => 0,
+            'targetMinutes' => 0,
+            'monthlyTargetMinutes' => 0,
+            'adjustedTargetMinutes' => 0,
+            'adjustedMonthlyTargetMinutes' => 0,
+            'workedMinutes' => 0,
+            'workedHours' => 0,
+            'paidAbsenceMinutes' => 0,
+            'paidAbsenceHours' => 0,
+            'actualMinutes' => 0,
+            'actualHours' => 0,
+            'overtimeMinutes' => 0,
+            'overtimeHours' => 0,
+            'entryCount' => 0,
+            'isFutureMonth' => false,
+        ];
+    }
+
+    /**
+     * Calculate absence minutes using actual schedule for each day.
+     *
+     * @param object[] $holidays
+     */
+    private function calculateAbsenceMinutes(int $employeeId, DateTime $start, DateTime $end, float $scope, array $holidays): int {
+        $holidayMap = [];
+        foreach ($holidays as $holiday) {
+            $holidayMap[$holiday->getDate()->format('Y-m-d')] = $holiday;
+        }
+
+        $totalMinutes = 0;
+        $current = clone $start;
+        while ($current <= $end) {
+            $dateStr = $current->format('Y-m-d');
+            $dayMinutes = $this->workScheduleService->getDailyMinutesForDate($employeeId, $current);
+
+            if ($dayMinutes > 0 && !isset($holidayMap[$dateStr])) {
+                $totalMinutes += (int)round($dayMinutes * $scope);
+            }
+            $current->modify('+1 day');
+        }
+
+        return $totalMinutes;
+    }
+}

--- a/lib/Service/OvertimePayoutService.php
+++ b/lib/Service/OvertimePayoutService.php
@@ -67,6 +67,12 @@ class OvertimePayoutService {
         // the balance negative. The net balance for the payout's year already
         // accounts for existing payouts, so a new payout of $minutes is only valid
         // while it does not exceed what remains.
+        //
+        // Accepted limitation: read-then-insert is not serialized, so two payouts
+        // created for the same employee within the same instant could both pass
+        // this check (TOCTOU). This endpoint is admin/HR-only and single-operator
+        // in practice, so a hard DB lock is deliberately deferred to the follow-up
+        // (#428) rather than added to this admin-only path.
         $year = (int)$payoutDate->format('Y');
         $available = $this->overtimeCalc->getNetOvertimeMinutes($employeeId, $year);
         if ($minutes > $available) {

--- a/lib/Service/OvertimePayoutService.php
+++ b/lib/Service/OvertimePayoutService.php
@@ -20,6 +20,7 @@ class OvertimePayoutService {
     public function __construct(
         private OvertimePayoutMapper $mapper,
         private AuditLogService $auditLogService,
+        private OvertimeCalculationService $overtimeCalc,
     ) {
     }
 
@@ -59,6 +60,21 @@ class OvertimePayoutService {
         }
         if (mb_strlen(trim($note)) < 10) {
             throw new \InvalidArgumentException('Bitte einen Grund mit mindestens 10 Zeichen angeben.');
+        }
+
+        // Server-side balance guard (#426): the frontend caps a payout at the
+        // available overtime balance, but a direct POST could bypass that and push
+        // the balance negative. The net balance for the payout's year already
+        // accounts for existing payouts, so a new payout of $minutes is only valid
+        // while it does not exceed what remains.
+        $year = (int)$payoutDate->format('Y');
+        $available = $this->overtimeCalc->getNetOvertimeMinutes($employeeId, $year);
+        if ($minutes > $available) {
+            throw new \InvalidArgumentException(sprintf(
+                'Die Auszahlung (%d Min.) überschreitet den verfügbaren Überstundensaldo (%d Min.).',
+                $minutes,
+                $available
+            ));
         }
 
         $payout = new OvertimePayout();

--- a/tests/Unit/Controller/CompensatoryOvertimeTest.php
+++ b/tests/Unit/Controller/CompensatoryOvertimeTest.php
@@ -5,25 +5,17 @@ declare(strict_types=1);
 namespace OCA\WorkTime\Tests\Unit\Controller;
 
 use DateTime;
-use OCA\WorkTime\Controller\ReportController;
 use OCA\WorkTime\Db\Absence;
-use OCA\WorkTime\Db\AbsenceMapper;
 use OCA\WorkTime\Db\Employee;
-use OCA\WorkTime\Db\TimeEntryMapper;
+use OCA\WorkTime\Db\OvertimePayoutMapper;
 use OCA\WorkTime\Service\AbsenceService;
 use OCA\WorkTime\Service\EmployeeService;
 use OCA\WorkTime\Service\HolidayService;
-use OCA\WorkTime\Service\PdfService;
-use OCA\WorkTime\Service\PermissionService;
-use OCA\WorkTime\Service\ProjectService;
+use OCA\WorkTime\Service\OvertimeCalculationService;
 use OCA\WorkTime\Service\TimeEntryService;
 use OCA\WorkTime\Service\WorkScheduleService;
 use OCA\WorkTime\Service\YearlyCarryoverService;
-use OCA\WorkTime\Service\OvertimePayoutService;
-use OCP\IL10N;
-use OCP\IRequest;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 
 /**
  * Regression test for #186 / #149: taking a Freizeitausgleich (compensatory) day
@@ -35,23 +27,15 @@ use ReflectionMethod;
  */
 class CompensatoryOvertimeTest extends TestCase {
 
-	private function makeController(WorkScheduleService $schedule): ReportController {
-		return new ReportController(
-			$this->createMock(IRequest::class),
-			'tester',
-			$this->createMock(TimeEntryService::class),
-			$this->createMock(TimeEntryMapper::class),
-			$this->createMock(AbsenceMapper::class),
-			$this->createMock(AbsenceService::class),
-			$this->createMock(EmployeeService::class),
-			$this->createMock(HolidayService::class),
-			$this->createMock(PermissionService::class),
-			$this->createMock(PdfService::class),
+	private function makeService(WorkScheduleService $schedule): OvertimeCalculationService {
+		return new OvertimeCalculationService(
 			$schedule,
 			$this->createMock(YearlyCarryoverService::class),
-			$this->createMock(OvertimePayoutService::class),
-			$this->createMock(ProjectService::class),
-			$this->createMock(IL10N::class),
+			$this->createMock(OvertimePayoutMapper::class),
+			$this->createMock(EmployeeService::class),
+			$this->createMock(TimeEntryService::class),
+			$this->createMock(AbsenceService::class),
+			$this->createMock(HolidayService::class),
 		);
 	}
 
@@ -60,12 +44,10 @@ class CompensatoryOvertimeTest extends TestCase {
 	 * @param object[] $absences
 	 */
 	private function overtimeFor(WorkScheduleService $schedule, array $entries, array $absences): int {
-		$controller = $this->makeController($schedule);
-		$method = new ReflectionMethod(ReportController::class, 'calculateMonthlyStats');
-		$method->setAccessible(true);
+		$service = $this->makeService($schedule);
 		// April 2026 is a fully completed month relative to any later run date,
 		// so the proportional ("up to today") logic equals the full month.
-		$stats = $method->invoke($controller, $this->employee(), 2026, 4, $entries, $absences, []);
+		$stats = $service->getMonthlyStats($this->employee(), 2026, 4, $entries, $absences, []);
 		return $stats['overtimeMinutes'];
 	}
 

--- a/tests/Unit/Controller/ProportionalOvertimeTodayTest.php
+++ b/tests/Unit/Controller/ProportionalOvertimeTodayTest.php
@@ -5,25 +5,17 @@ declare(strict_types=1);
 namespace OCA\WorkTime\Tests\Unit\Controller;
 
 use DateTime;
-use OCA\WorkTime\Controller\ReportController;
 use OCA\WorkTime\Db\Absence;
-use OCA\WorkTime\Db\AbsenceMapper;
 use OCA\WorkTime\Db\Employee;
-use OCA\WorkTime\Db\TimeEntryMapper;
+use OCA\WorkTime\Db\OvertimePayoutMapper;
 use OCA\WorkTime\Service\AbsenceService;
 use OCA\WorkTime\Service\EmployeeService;
 use OCA\WorkTime\Service\HolidayService;
-use OCA\WorkTime\Service\PdfService;
-use OCA\WorkTime\Service\PermissionService;
-use OCA\WorkTime\Service\ProjectService;
+use OCA\WorkTime\Service\OvertimeCalculationService;
 use OCA\WorkTime\Service\TimeEntryService;
 use OCA\WorkTime\Service\WorkScheduleService;
 use OCA\WorkTime\Service\YearlyCarryoverService;
-use OCA\WorkTime\Service\OvertimePayoutService;
-use OCP\IL10N;
-use OCP\IRequest;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 
 /**
  * Regression test for #251.5: the running ("current") day must not produce a
@@ -40,31 +32,23 @@ class ProportionalOvertimeTodayTest extends TestCase {
 
 	private const DAILY = 480;
 
-	private function makeController(WorkScheduleService $schedule, string $today): ReportController {
-		$controller = new class(
-			$this->createMock(IRequest::class),
-			'tester',
-			$this->createMock(TimeEntryService::class),
-			$this->createMock(TimeEntryMapper::class),
-			$this->createMock(AbsenceMapper::class),
-			$this->createMock(AbsenceService::class),
-			$this->createMock(EmployeeService::class),
-			$this->createMock(HolidayService::class),
-			$this->createMock(PermissionService::class),
-			$this->createMock(PdfService::class),
+	private function makeService(WorkScheduleService $schedule, string $today): OvertimeCalculationService {
+		$service = new class(
 			$schedule,
 			$this->createMock(YearlyCarryoverService::class),
-			$this->createMock(OvertimePayoutService::class),
-			$this->createMock(ProjectService::class),
-			$this->createMock(IL10N::class),
-		) extends ReportController {
+			$this->createMock(OvertimePayoutMapper::class),
+			$this->createMock(EmployeeService::class),
+			$this->createMock(TimeEntryService::class),
+			$this->createMock(AbsenceService::class),
+			$this->createMock(HolidayService::class),
+		) extends OvertimeCalculationService {
 			public string $pinnedToday = '';
 			protected function currentDate(): DateTime {
 				return new DateTime($this->pinnedToday);
 			}
 		};
-		$controller->pinnedToday = $today;
-		return $controller;
+		$service->pinnedToday = $today;
+		return $service;
 	}
 
 	/**
@@ -72,11 +56,9 @@ class ProportionalOvertimeTodayTest extends TestCase {
 	 * @param object[] $absences
 	 */
 	private function overtimeFor(string $today, array $entries, array $absences): int {
-		$controller = $this->makeController($this->schedule(), $today);
-		$method = new ReflectionMethod(ReportController::class, 'calculateMonthlyStats');
-		$method->setAccessible(true);
+		$service = $this->makeService($this->schedule(), $today);
 		// June 2026 is the "current" month relative to the pinned today.
-		$stats = $method->invoke($controller, $this->employee(), 2026, 6, $entries, $absences, []);
+		$stats = $service->getMonthlyStats($this->employee(), 2026, 6, $entries, $absences, []);
 		return $stats['overtimeMinutes'];
 	}
 

--- a/tests/Unit/Controller/ReportControllerTest.php
+++ b/tests/Unit/Controller/ReportControllerTest.php
@@ -21,6 +21,7 @@ use OCA\WorkTime\Service\TimeEntryService;
 use OCA\WorkTime\Service\WorkScheduleService;
 use OCA\WorkTime\Service\YearlyCarryoverService;
 use OCA\WorkTime\Service\OvertimePayoutService;
+use OCA\WorkTime\Service\OvertimeCalculationService;
 use OCP\IL10N;
 use OCP\IRequest;
 use PHPUnit\Framework\TestCase;
@@ -58,6 +59,7 @@ class ReportControllerTest extends TestCase {
             $this->createMock(WorkScheduleService::class),
             $this->createMock(YearlyCarryoverService::class),
             $this->createMock(OvertimePayoutService::class),
+            $this->createMock(OvertimeCalculationService::class),
             $this->projectService,
             $this->createMock(IL10N::class),
         );
@@ -146,7 +148,8 @@ class ReportControllerTest extends TestCase {
             $this->createMock(AbsenceMapper::class), $this->createMock(AbsenceService::class),
             $this->employeeService, $this->createMock(HolidayService::class), $perm,
             $this->createMock(PdfService::class), $this->createMock(WorkScheduleService::class),
-            $this->createMock(YearlyCarryoverService::class), $this->createMock(OvertimePayoutService::class), $this->projectService,
+            $this->createMock(YearlyCarryoverService::class), $this->createMock(OvertimePayoutService::class),
+            $this->createMock(OvertimeCalculationService::class), $this->projectService,
             $this->createMock(IL10N::class),
         );
 

--- a/tests/Unit/Service/OvertimeCalculationServiceTest.php
+++ b/tests/Unit/Service/OvertimeCalculationServiceTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Tests\Unit\Service;
+
+use DateTime;
+use OCA\WorkTime\Db\Employee;
+use OCA\WorkTime\Db\OvertimePayoutMapper;
+use OCA\WorkTime\Service\AbsenceService;
+use OCA\WorkTime\Service\EmployeeService;
+use OCA\WorkTime\Service\HolidayService;
+use OCA\WorkTime\Service\OvertimeCalculationService;
+use OCA\WorkTime\Service\TimeEntryService;
+use OCA\WorkTime\Service\WorkScheduleService;
+use OCA\WorkTime\Service\YearlyCarryoverService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the net overtime balance formula used by the payout guard (#426):
+ * net = Σ monthly overtime (up to today) + carryover − already paid out.
+ *
+ * getMonthlyStats() itself is exercised by CompensatoryOvertimeTest and
+ * ProportionalOvertimeTodayTest; here it is stubbed so the balance aggregation
+ * (month loop, future-month cutoff, carryover, payout subtraction) is asserted
+ * in isolation.
+ */
+class OvertimeCalculationServiceTest extends TestCase {
+
+    private EmployeeService $employeeService;
+    private TimeEntryService $timeEntryService;
+    private AbsenceService $absenceService;
+    private HolidayService $holidayService;
+    private YearlyCarryoverService $carryoverService;
+    private OvertimePayoutMapper $payoutMapper;
+
+    /**
+     * @param int $perMonthOvertime overtime minutes each month's stats reports
+     */
+    private function makeService(int $perMonthOvertime, string $today): OvertimeCalculationService {
+        $this->employeeService = $this->createMock(EmployeeService::class);
+        $this->timeEntryService = $this->createMock(TimeEntryService::class);
+        $this->absenceService = $this->createMock(AbsenceService::class);
+        $this->holidayService = $this->createMock(HolidayService::class);
+        $this->carryoverService = $this->createMock(YearlyCarryoverService::class);
+        $this->payoutMapper = $this->createMock(OvertimePayoutMapper::class);
+
+        $employee = new Employee();
+        $employee->setId(1);
+        $employee->setFederalState('BY');
+        $this->employeeService->method('find')->willReturn($employee);
+        $this->timeEntryService->method('findByEmployeeAndMonth')->willReturn([]);
+        $this->absenceService->method('findByEmployeeAndMonth')->willReturn([]);
+        $this->holidayService->method('findByMonth')->willReturn([]);
+
+        return new class(
+            $this->createMock(WorkScheduleService::class),
+            $this->carryoverService,
+            $this->payoutMapper,
+            $this->employeeService,
+            $this->timeEntryService,
+            $this->absenceService,
+            $this->holidayService,
+            $perMonthOvertime,
+            $today,
+        ) extends OvertimeCalculationService {
+            public function __construct(
+                WorkScheduleService $ws,
+                YearlyCarryoverService $co,
+                OvertimePayoutMapper $pm,
+                EmployeeService $es,
+                TimeEntryService $ts,
+                AbsenceService $as,
+                HolidayService $hs,
+                private int $perMonthOvertime,
+                private string $pinnedToday,
+            ) {
+                parent::__construct($ws, $co, $pm, $es, $ts, $as, $hs);
+            }
+
+            protected function currentDate(): DateTime {
+                return new DateTime($this->pinnedToday);
+            }
+
+            public function getMonthlyStats(
+                Employee $employee,
+                int $year,
+                int $month,
+                array $timeEntries,
+                array $absences,
+                array $holidays
+            ): array {
+                return ['overtimeMinutes' => $this->perMonthOvertime];
+            }
+        };
+    }
+
+    public function testNetBalanceSumsMonthsPlusCarryoverMinusPaidOut(): void {
+        // "today" = 2026-03-15 → months Jan/Feb/Mar accrue, April onward is skipped.
+        $service = $this->makeService(perMonthOvertime: 100, today: '2026-03-15');
+        $this->carryoverService->method('getOvertimeCarryoverMinutes')->willReturn(50);
+        $this->payoutMapper->method('sumMinutesByEmployeeAndYear')->willReturn(120);
+
+        // 3 × 100 + 50 − 120 = 230
+        $this->assertSame(230, $service->getNetOvertimeMinutes(1, 2026));
+    }
+
+    public function testFutureMonthsAreExcludedFromBalance(): void {
+        // "today" = 2026-01-10 → only January accrues.
+        $service = $this->makeService(perMonthOvertime: 480, today: '2026-01-10');
+        $this->carryoverService->method('getOvertimeCarryoverMinutes')->willReturn(0);
+        $this->payoutMapper->method('sumMinutesByEmployeeAndYear')->willReturn(0);
+
+        $this->assertSame(480, $service->getNetOvertimeMinutes(1, 2026));
+    }
+
+    public function testExistingPayoutsCanDriveBalanceNegative(): void {
+        // Carryover 60, one month of 100 overtime, but 400 already paid out.
+        $service = $this->makeService(perMonthOvertime: 100, today: '2026-01-10');
+        $this->carryoverService->method('getOvertimeCarryoverMinutes')->willReturn(60);
+        $this->payoutMapper->method('sumMinutesByEmployeeAndYear')->willReturn(400);
+
+        // 100 + 60 − 400 = -240
+        $this->assertSame(-240, $service->getNetOvertimeMinutes(1, 2026));
+    }
+}

--- a/tests/Unit/Service/OvertimePayoutServiceTest.php
+++ b/tests/Unit/Service/OvertimePayoutServiceTest.php
@@ -8,22 +8,28 @@ use DateTime;
 use OCA\WorkTime\Db\OvertimePayout;
 use OCA\WorkTime\Db\OvertimePayoutMapper;
 use OCA\WorkTime\Service\AuditLogService;
+use OCA\WorkTime\Service\OvertimeCalculationService;
 use OCA\WorkTime\Service\OvertimePayoutService;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Covers the overtime payout creation/validation logic (#401).
+ * Covers the overtime payout creation/validation logic (#401, #426).
  */
 class OvertimePayoutServiceTest extends TestCase {
 
     private OvertimePayoutMapper $mapper;
     private AuditLogService $auditLogService;
+    private OvertimeCalculationService $overtimeCalc;
     private OvertimePayoutService $service;
 
     protected function setUp(): void {
         $this->mapper = $this->createMock(OvertimePayoutMapper::class);
         $this->auditLogService = $this->createMock(AuditLogService::class);
-        $this->service = new OvertimePayoutService($this->mapper, $this->auditLogService);
+        $this->overtimeCalc = $this->createMock(OvertimeCalculationService::class);
+        // By default there is plenty of overtime available, so the balance guard
+        // (#426) does not interfere with the other creation-path assertions.
+        $this->overtimeCalc->method('getNetOvertimeMinutes')->willReturn(100000);
+        $this->service = new OvertimePayoutService($this->mapper, $this->auditLogService, $this->overtimeCalc);
     }
 
     public function testCreateRejectsZeroMinutes(): void {
@@ -60,6 +66,38 @@ class OvertimePayoutServiceTest extends TestCase {
         $this->assertSame(42, $result->getId());
         $this->assertSame(600, $result->getMinutes());
         $this->assertSame('Auszahlung mit Juni-Gehalt', $result->getNote());
+    }
+
+    public function testCreateRejectsPayoutExceedingAvailableBalance(): void {
+        // #426: available balance is 300 min; a 600 min payout must be rejected
+        // server-side even though the frontend cap could be bypassed via direct POST.
+        $overtimeCalc = $this->createMock(OvertimeCalculationService::class);
+        $overtimeCalc->expects($this->once())
+            ->method('getNetOvertimeMinutes')
+            ->with(1, 2026)
+            ->willReturn(300);
+        $service = new OvertimePayoutService($this->mapper, $this->auditLogService, $overtimeCalc);
+
+        $this->mapper->expects($this->never())->method('insert');
+        $this->expectException(\InvalidArgumentException::class);
+        $service->create(1, new DateTime('2026-06-30'), 600, 'Auszahlung mit Juni-Gehalt', 'admin');
+    }
+
+    public function testCreateAllowsPayoutExactlyAtAvailableBalance(): void {
+        // #426: a payout equal to the available balance is permitted (drives it to 0).
+        $overtimeCalc = $this->createMock(OvertimeCalculationService::class);
+        $overtimeCalc->method('getNetOvertimeMinutes')->willReturn(600);
+        $service = new OvertimePayoutService($this->mapper, $this->auditLogService, $overtimeCalc);
+
+        $this->mapper->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function (OvertimePayout $p) {
+                $p->setId(1);
+                return $p;
+            });
+
+        $result = $service->create(1, new DateTime('2026-06-30'), 600, 'Auszahlung mit Juni-Gehalt', 'admin');
+        $this->assertSame(600, $result->getMinutes());
     }
 
     public function testGetPaidOutMinutesDelegatesToMapper(): void {


### PR DESCRIPTION
## Was

Server-seitiger Balance-Guard für Überstunden-Auszahlungen (#426, aus Bot-Review-Finding #4 zu PR #425).

Bisher prüft nur das Frontend, dass eine Auszahlung den verfügbaren Überstundensaldo nicht überschreitet. Ein direkter POST umging diesen UI-Deckel und konnte einen negativen Saldo erzeugen.

## Wie

- **Extraktion:** Die Überstunden-/Monats-Berechnung wird 1:1 aus `ReportController` in einen neuen `OvertimeCalculationService` gezogen (`getMonthlyStats`/`getRangeStats` unverändert verschoben, neuer `getNetOvertimeMinutes`). ReportController delegiert an allen 5 Call-Sites.
- **Guard:** `OvertimePayoutService::create()` validiert `minutes` gegen den Netto-Saldo des Auszahlungsjahres (`Σ Monats-Überstunden + Übertrag − bereits ausgezahlt`) und lehnt überschreitende Beträge ab.
- **Zyklus-Vermeidung:** Der Calc-Service hängt am `OvertimePayoutMapper`, nicht am Payout-Service.

## Tests

- Verhalten der Report-Endpunkte unverändert: die bestehenden Überstunden-Tests (`CompensatoryOvertimeTest`, `ProportionalOvertimeTodayTest`) laufen jetzt gegen den extrahierten Service und bleiben grün.
- Neu: `OvertimeCalculationServiceTest` (Saldo-Formel inkl. Zukunfts-Monats-Cutoff), Guard rot→grün in `OvertimePayoutServiceTest` (über Saldo → abgelehnt, exakt am Saldo → erlaubt).
- **192 Tests grün** (container-frei, PHP 8.4).

Fixes #426