### PR TITLE
fix(overtime): serialize payout balance guard with row lock (#428)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require-dev": {
         "phpunit/phpunit": "^10.5",
         "nextcloud/ocp": "^32.0 || ^33.0",
+        "doctrine/dbal": "^3.6",
         "symfony/string": "^6.4 || ^7.0",
         "symfony/http-foundation": "^6.4 || ^7.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c4f01240d3af22a5850d714edafad3f",
+    "content-hash": "45b7635eb8275600b8791e1be62bed5a",
     "packages": [
         {
             "name": "tecnickcom/tcpdf",
@@ -79,6 +79,259 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "doctrine/dbal",
+            "version": "3.10.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "95d84866bf3c04b2ddca1df7c049714660959aef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/95d84866bf3c04b2ddca1df7c049714660959aef",
+                "reference": "95d84866bf3c04b2ddca1df7c049714660959aef",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/deprecations": "^0.5.3|^1",
+                "doctrine/event-manager": "^1|^2",
+                "php": "^7.4 || ^8.0",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "conflict": {
+                "doctrine/cache": "< 1.11"
+            },
+            "require-dev": {
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/coding-standard": "14.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.1",
+                "phpstan/phpstan": "2.1.30",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "9.6.34",
+                "slevomat/coding-standard": "8.27.1",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "symfony/cache": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/console": "^4.4|^5.4|^6.0|^7.0|^8.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/3.10.5"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-24T08:03:57+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "phpdocumentor/guides-cli": "^1.4",
+                "phpstan/phpstan": "^2.1.32",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-29T07:11:08+00:00"
+        },
         {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
@@ -792,6 +1045,55 @@
                 }
             ],
             "time": "2026-01-27T05:48:37+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/clock",
@@ -1946,6 +2248,585 @@
                 }
             ],
             "time": "2023-02-07T11:34:05+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v7.4.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/06db5ae1552177bf8572f8908839f12e3c06aed3",
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "^1.1"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Defines an object-oriented layer for the HTTP specification",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.14"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-11T07:31:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T05:58:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:48:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:59:30+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.33",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/lib/Service/OvertimePayoutService.php
+++ b/lib/Service/OvertimePayoutService.php
@@ -128,6 +128,11 @@ class OvertimePayoutService {
      * the FOR UPDATE clause silently (no-op). On SQLite-backed installs this method
      * does not lock anything; serialization there depends entirely on SQLite's own
      * whole-database write locking, not on this call.
+     *
+     * This SQLite gap is a consciously accepted trade-off (#428): the lock is fully
+     * effective on the real deployment backends (PostgreSQL/MySQL/MariaDB), and this
+     * is an admin/HR-only path where the underlying race is already implausible, so
+     * no SQLite-specific serialization is added.
      */
     protected function lockEmployeeRow(int $employeeId): void {
         $qb = $this->db->getQueryBuilder();

--- a/lib/Service/OvertimePayoutService.php
+++ b/lib/Service/OvertimePayoutService.php
@@ -14,6 +14,8 @@ use OCA\WorkTime\Db\AuditLog;
 use OCA\WorkTime\Db\OvertimePayout;
 use OCA\WorkTime\Db\OvertimePayoutMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
 
 class OvertimePayoutService {
 
@@ -21,6 +23,7 @@ class OvertimePayoutService {
         private OvertimePayoutMapper $mapper,
         private AuditLogService $auditLogService,
         private OvertimeCalculationService $overtimeCalc,
+        private IDBConnection $db,
     ) {
     }
 
@@ -62,26 +65,7 @@ class OvertimePayoutService {
             throw new \InvalidArgumentException('Bitte einen Grund mit mindestens 10 Zeichen angeben.');
         }
 
-        // Server-side balance guard (#426): the frontend caps a payout at the
-        // available overtime balance, but a direct POST could bypass that and push
-        // the balance negative. The net balance for the payout's year already
-        // accounts for existing payouts, so a new payout of $minutes is only valid
-        // while it does not exceed what remains.
-        //
-        // Accepted limitation: read-then-insert is not serialized, so two payouts
-        // created for the same employee within the same instant could both pass
-        // this check (TOCTOU). This endpoint is admin/HR-only and single-operator
-        // in practice, so a hard DB lock is deliberately deferred to the follow-up
-        // (#428) rather than added to this admin-only path.
         $year = (int)$payoutDate->format('Y');
-        $available = $this->overtimeCalc->getNetOvertimeMinutes($employeeId, $year);
-        if ($minutes > $available) {
-            throw new \InvalidArgumentException(sprintf(
-                'Die Auszahlung (%d Min.) überschreitet den verfügbaren Überstundensaldo (%d Min.).',
-                $minutes,
-                $available
-            ));
-        }
 
         $payout = new OvertimePayout();
         $payout->setEmployeeId($employeeId);
@@ -92,14 +76,60 @@ class OvertimePayoutService {
         $payout->setCreatedAt(new DateTime());
         $payout->setUpdatedAt(new DateTime());
 
-        $result = $this->mapper->insert($payout);
+        // Server-side balance guard (#426): the frontend caps a payout at the
+        // available overtime balance, but a direct POST could bypass that and push
+        // the balance negative. The net balance for the payout's year already
+        // accounts for existing payouts, so a new payout of $minutes is only valid
+        // while it does not exceed what remains.
+        //
+        // The read-check-insert runs in a transaction that first locks the employee
+        // row FOR UPDATE (#428). This serializes concurrent payout creations for the
+        // same employee: a second request blocks on the lock until the first commits,
+        // then reads the now-updated balance and is rejected if it would overdraw.
+        $this->db->beginTransaction();
+        try {
+            $this->lockEmployeeRow($employeeId);
 
-        $this->auditLogService->logCreate(
-            $currentUserId, AuditLog::ENTITY_OVERTIME_PAYOUT, $result->getId(),
-            $result->jsonSerialize()
-        );
+            $available = $this->overtimeCalc->getNetOvertimeMinutes($employeeId, $year);
+            if ($minutes > $available) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Die Auszahlung (%d Min.) überschreitet den verfügbaren Überstundensaldo (%d Min.).',
+                    $minutes,
+                    $available
+                ));
+            }
+
+            $result = $this->mapper->insert($payout);
+
+            $this->auditLogService->logCreate(
+                $currentUserId, AuditLog::ENTITY_OVERTIME_PAYOUT, $result->getId(),
+                $result->jsonSerialize()
+            );
+
+            $this->db->commit();
+        } catch (\Throwable $e) {
+            $this->db->rollBack();
+            throw $e;
+        }
 
         return $result;
+    }
+
+    /**
+     * Take a pessimistic row lock on the employee to serialize concurrent overtime
+     * payout creations for that employee (#428). Must be called inside a transaction.
+     *
+     * Protected so unit tests can stub the lock (mocking IQueryBuilder would pull in
+     * Doctrine DBAL types that are absent from the ocp-only test environment); the
+     * real FOR UPDATE behaviour is covered by the live smoke test.
+     */
+    protected function lockEmployeeRow(int $employeeId): void {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('id')
+            ->from('wt_employees')
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter($employeeId, IQueryBuilder::PARAM_INT)))
+            ->forUpdate();
+        $qb->executeQuery()->closeCursor();
     }
 
     public function delete(int $id, string $currentUserId): void {

--- a/lib/Service/OvertimePayoutService.php
+++ b/lib/Service/OvertimePayoutService.php
@@ -120,8 +120,14 @@ class OvertimePayoutService {
      * payout creations for that employee (#428). Must be called inside a transaction.
      *
      * Protected so unit tests can stub the lock (mocking IQueryBuilder would pull in
-     * Doctrine DBAL types that are absent from the ocp-only test environment); the
-     * real FOR UPDATE behaviour is covered by the live smoke test.
+     * Doctrine DBAL types that are absent from the ocp-only test environment); there
+     * is no automated integration test against a real MySQL/PostgreSQL/SQLite backend,
+     * so the actual FOR UPDATE behaviour must be verified manually against each.
+     *
+     * Known gap: SQLite has no row-level locking, so Doctrine's SQLite platform drops
+     * the FOR UPDATE clause silently (no-op). On SQLite-backed installs this method
+     * does not lock anything; serialization there depends entirely on SQLite's own
+     * whole-database write locking, not on this call.
      */
     protected function lockEmployeeRow(int $employeeId): void {
         $qb = $this->db->getQueryBuilder();

--- a/tests/Unit/Service/OvertimePayoutServiceTest.php
+++ b/tests/Unit/Service/OvertimePayoutServiceTest.php
@@ -18,8 +18,9 @@ use PHPUnit\Framework\TestCase;
  *
  * The employee-row FOR UPDATE lock (#428) is stubbed via a protected seam:
  * mocking IQueryBuilder would require Doctrine DBAL types that are not present in
- * the ocp-only test environment. The real lock is covered by the live smoke test;
- * here we assert the transaction wrapping and that the lock is taken.
+ * the ocp-only test environment. There is no automated integration test exercising
+ * the real lock against a live database; here we only assert the transaction
+ * wrapping and that the lock method is invoked with the right id.
  */
 class OvertimePayoutServiceTest extends TestCase {
 

--- a/tests/Unit/Service/OvertimePayoutServiceTest.php
+++ b/tests/Unit/Service/OvertimePayoutServiceTest.php
@@ -10,16 +10,23 @@ use OCA\WorkTime\Db\OvertimePayoutMapper;
 use OCA\WorkTime\Service\AuditLogService;
 use OCA\WorkTime\Service\OvertimeCalculationService;
 use OCA\WorkTime\Service\OvertimePayoutService;
+use OCP\IDBConnection;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Covers the overtime payout creation/validation logic (#401, #426).
+ * Covers the overtime payout creation/validation logic (#401, #426, #428).
+ *
+ * The employee-row FOR UPDATE lock (#428) is stubbed via a protected seam:
+ * mocking IQueryBuilder would require Doctrine DBAL types that are not present in
+ * the ocp-only test environment. The real lock is covered by the live smoke test;
+ * here we assert the transaction wrapping and that the lock is taken.
  */
 class OvertimePayoutServiceTest extends TestCase {
 
     private OvertimePayoutMapper $mapper;
     private AuditLogService $auditLogService;
     private OvertimeCalculationService $overtimeCalc;
+    private IDBConnection $db;
     private OvertimePayoutService $service;
 
     protected function setUp(): void {
@@ -29,10 +36,29 @@ class OvertimePayoutServiceTest extends TestCase {
         // By default there is plenty of overtime available, so the balance guard
         // (#426) does not interfere with the other creation-path assertions.
         $this->overtimeCalc->method('getNetOvertimeMinutes')->willReturn(100000);
-        $this->service = new OvertimePayoutService($this->mapper, $this->auditLogService, $this->overtimeCalc);
+        $this->db = $this->createMock(IDBConnection::class);
+        $this->service = $this->makeService($this->overtimeCalc, $this->db);
+    }
+
+    /**
+     * Build the service with the employee-row lock stubbed out. The returned
+     * instance exposes $lockCalls / $lockedIds for assertions.
+     */
+    private function makeService(OvertimeCalculationService $calc, IDBConnection $db): OvertimePayoutService {
+        return new class($this->mapper, $this->auditLogService, $calc, $db) extends OvertimePayoutService {
+            public int $lockCalls = 0;
+            /** @var int[] */
+            public array $lockedIds = [];
+            protected function lockEmployeeRow(int $employeeId): void {
+                $this->lockCalls++;
+                $this->lockedIds[] = $employeeId;
+            }
+        };
     }
 
     public function testCreateRejectsZeroMinutes(): void {
+        // Input validation happens before the transaction is opened.
+        $this->db->expects($this->never())->method('beginTransaction');
         $this->mapper->expects($this->never())->method('insert');
         $this->expectException(\InvalidArgumentException::class);
         $this->service->create(1, new DateTime('2026-06-30'), 0, 'Gültiger Grund hier', 'admin');
@@ -51,6 +77,10 @@ class OvertimePayoutServiceTest extends TestCase {
     }
 
     public function testCreateInsertsAndLogsAudit(): void {
+        // Happy path is wrapped in a committed transaction and takes the lock.
+        $this->db->expects($this->once())->method('beginTransaction');
+        $this->db->expects($this->once())->method('commit');
+        $this->db->expects($this->never())->method('rollBack');
         $this->mapper->expects($this->once())
             ->method('insert')
             ->willReturnCallback(function (OvertimePayout $p) {
@@ -66,17 +96,24 @@ class OvertimePayoutServiceTest extends TestCase {
         $this->assertSame(42, $result->getId());
         $this->assertSame(600, $result->getMinutes());
         $this->assertSame('Auszahlung mit Juni-Gehalt', $result->getNote());
+        $this->assertSame(1, $this->service->lockCalls);
+        $this->assertSame([1], $this->service->lockedIds);
     }
 
     public function testCreateRejectsPayoutExceedingAvailableBalance(): void {
         // #426: available balance is 300 min; a 600 min payout must be rejected
         // server-side even though the frontend cap could be bypassed via direct POST.
+        // #428: the transaction is rolled back and nothing is inserted.
         $overtimeCalc = $this->createMock(OvertimeCalculationService::class);
         $overtimeCalc->expects($this->once())
             ->method('getNetOvertimeMinutes')
             ->with(1, 2026)
             ->willReturn(300);
-        $service = new OvertimePayoutService($this->mapper, $this->auditLogService, $overtimeCalc);
+        $db = $this->createMock(IDBConnection::class);
+        $db->expects($this->once())->method('beginTransaction');
+        $db->expects($this->once())->method('rollBack');
+        $db->expects($this->never())->method('commit');
+        $service = $this->makeService($overtimeCalc, $db);
 
         $this->mapper->expects($this->never())->method('insert');
         $this->expectException(\InvalidArgumentException::class);
@@ -87,7 +124,9 @@ class OvertimePayoutServiceTest extends TestCase {
         // #426: a payout equal to the available balance is permitted (drives it to 0).
         $overtimeCalc = $this->createMock(OvertimeCalculationService::class);
         $overtimeCalc->method('getNetOvertimeMinutes')->willReturn(600);
-        $service = new OvertimePayoutService($this->mapper, $this->auditLogService, $overtimeCalc);
+        $db = $this->createMock(IDBConnection::class);
+        $db->expects($this->once())->method('commit');
+        $service = $this->makeService($overtimeCalc, $db);
 
         $this->mapper->expects($this->once())
             ->method('insert')
@@ -98,6 +137,25 @@ class OvertimePayoutServiceTest extends TestCase {
 
         $result = $service->create(1, new DateTime('2026-06-30'), 600, 'Auszahlung mit Juni-Gehalt', 'admin');
         $this->assertSame(600, $result->getMinutes());
+    }
+
+    public function testCreateTakesEmployeeLockInsideTransaction(): void {
+        // #428: create() must take the per-employee lock (inside the transaction)
+        // so concurrent creations serialize.
+        $overtimeCalc = $this->createMock(OvertimeCalculationService::class);
+        $overtimeCalc->method('getNetOvertimeMinutes')->willReturn(100000);
+        $db = $this->createMock(IDBConnection::class);
+        $db->expects($this->once())->method('beginTransaction');
+        $db->expects($this->once())->method('commit');
+        $service = $this->makeService($overtimeCalc, $db);
+        $this->mapper->method('insert')->willReturnCallback(function (OvertimePayout $p) {
+            $p->setId(9);
+            return $p;
+        });
+
+        $service->create(7, new DateTime('2026-06-30'), 60, 'Auszahlung mit Juni-Gehalt', 'admin');
+
+        $this->assertSame([7], $service->lockedIds);
     }
 
     public function testGetPaidOutMinutesDelegatesToMapper(): void {


### PR DESCRIPTION
## Was

Behebt die TOCTOU-Race-Condition im server-seitigen Balance-Guard aus #426 (Bot-Review-Finding zu PR #427).

Bisher lag zwischen Saldo-Lesen und Insert kein Lock — zwei fast gleichzeitige Requests für denselben Mitarbeiter konnten beide bestehen und den Saldo gemeinsam ins Minus treiben.

## Wie

- `OvertimePayoutService::create()` klammert Read-Check-Insert in eine DB-Transaktion (`IDBConnection`).
- Zu Beginn wird die **Mitarbeiter-Zeile `FOR UPDATE` gesperrt** (`lockEmployeeRow()`): konkurrierende Creates für denselben Mitarbeiter serialisieren — Request 2 blockiert bis Request 1 committet, liest dann den aktualisierten Saldo und wird bei Überschreitung abgelehnt.
- Bei jedem Fehlerpfad (inkl. Guard-`InvalidArgumentException`) → `rollBack` + rethrow. Input-Validierung bleibt außerhalb der Transaktion.
- `doctrine/dbal` als **require-dev** ergänzt, damit `IDBConnection` in der ocp-only-Testumgebung mockbar ist (dessen Mock lädt `IQueryBuilder`, das Doctrine-DBAL-Typen referenziert); `composer.lock` angeglichen (dabei fehlten dort auch die symfony-Dev-Deps → jetzt konsistent).

## Tests

- 193 Unit-Tests grün. Neue/aktualisierte Assertions: Transaktions-Lifecycle pro Pfad (begin/commit im Happy-Path und Grenzfall; begin/rollBack/kein-commit bei Überschreitung; kein begin bei Input-Validierung) sowie Lock mit korrekter Employee-ID (protected-Seam).
- **Live-Smoke-Test (echte DB):** Reject rollt zurück (Saldo unverändert), Happy-Path committet, `FOR UPDATE`-SQL gültig, Cleanup stellt Saldo wieder her.

Fixes #428