### PR TITLE
ci: skip claude-review on release PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,8 +6,13 @@ on:
 
 jobs:
   claude-review:
-    # Only review non-draft PRs
-    if: github.event.pull_request.draft == false
+    # Only review non-draft PRs. Skip release PRs (release/* -> main): their diff
+    # is the full accumulated release since the last tag, which was already reviewed
+    # on the individual feature PRs to develop. Re-reviewing the whole batch is
+    # redundant and reliably exhausts the turn limit, failing the run for no reason.
+    if: >-
+      github.event.pull_request.draft == false &&
+      !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Problem
Der `claude-review`-Job schlägt bei **Release-PRs** (`release/vX.Y.Z` → `main`) zuverlässig fehl: „Reached maximum number of turns (50)". Ursache: Der Release-Branch wird von `develop` abgezweigt, daher ist der Diff gegen `main` die **komplette Release-Delta** seit dem letzten Tag (alle Features/Fixes zusammen). Der Review-Agent kommt damit nie zum Verdict → roter Lauf + Fehlmail bei jedem Release (zuletzt v0.12.3).

## Warum überspringen kein Review-Loch reißt
Der Code in einem Release-PR wurde bereits reviewt — auf den einzelnen Feature-PRs gegen `develop` (jeweils claude-review APPROVED). Das Release-PR-Review ist eine Wiederholung derselben, schon geprüften Änderungen. Zudem mergen wir Release-PRs ohnehin per `--admin`, der Review-Status gated den Merge also nie.

## Fix
`if:`-Guard ergänzt: Job läuft nicht mehr, wenn der Head-Branch mit `release/` beginnt.

Betrifft nur worktime.