### PR TITLE
fix(time-entries): Max-Tagesarbeitszeit auf Netto statt Brutto prüfen (#437)

### DIFF
--- a/lib/Service/TimeEntryService.php
+++ b/lib/Service/TimeEntryService.php
@@ -759,7 +759,6 @@ class TimeEntryService {
         }
 
         $warnings = [];
-        $grossHours = $totalGrossMinutes / 60;
 
         // §4 ArbZG minimum break, evaluated on the whole day. Upper step is
         // 9h + break6h gross (not a flat 9h), consistent with suggestBreak()/
@@ -779,12 +778,17 @@ class TimeEntryService {
             );
         }
 
-        // Maximum daily working hours, evaluated on the whole day.
+        // Maximum daily working hours (§3 ArbZG). The legal cap targets the
+        // WORKING time (net), not the presence span — mirrors suggestBreak()/
+        // dayWarnings §4 above and the fix in #403. Comparing gross wrongly
+        // flagged days whose net time is within the limit (#437).
+        $netMinutes = max(0, $totalGrossMinutes - $totalBreakMinutes);
+        $netHours = $netMinutes / 60;
         $maxHours = $this->settingsMapper->getValueAsFloat(CompanySetting::KEY_MAX_DAILY_HOURS);
-        if ($maxHours > 0 && $grossHours > $maxHours) {
+        if ($maxHours > 0 && $netHours > $maxHours) {
             $warnings[] = $this->l->t(
                 'Maximale tägliche Arbeitszeit (%1$s Std.) überschritten: an diesem Tag sind %2$s Std. erfasst.',
-                [(string)$maxHours, (string)round($grossHours, 2)]
+                [(string)$maxHours, (string)round($netHours, 2)]
             );
         }
 

--- a/lib/Service/TimeEntryService.php
+++ b/lib/Service/TimeEntryService.php
@@ -710,10 +710,11 @@ class TimeEntryService {
      * and returned as non-blocking warnings.
      *
      * Convention (kept consistent with validateBreak()/suggestBreak()): the §4
-     * threshold and the max-hours check are evaluated against the total GROSS
-     * minutes of the day (sum of each entry's start→end span, excluding the gaps
-     * between entries). Gaps between consecutive entries count as break time, on
-     * top of the explicitly recorded break minutes.
+     * threshold is evaluated against the total GROSS minutes of the day (sum of
+     * each entry's start→end span, excluding the gaps between entries), while the
+     * §3 max-hours check is evaluated against the total NET minutes (gross minus
+     * breaks, #437). Gaps between consecutive entries count as break time, on top
+     * of the explicitly recorded break minutes.
      *
      * @param TimeEntry[] $entries All time entries of one day (same date).
      * @return string[] Human-readable warning messages (empty when compliant).

--- a/tests/Unit/Service/TimeEntryServiceTest.php
+++ b/tests/Unit/Service/TimeEntryServiceTest.php
@@ -693,4 +693,48 @@ class TimeEntryServiceTest extends TestCase {
             ->with([])->willReturn([]);
         $this->assertSame([], $this->service->findSubmittedMonths([]));
     }
+
+    /**
+     * #437: The §3 ArbZG max-daily-hours warning must evaluate NET working time
+     * (after breaks), not the gross presence span. 08:00–20:40 minus 45 min
+     * break is 11:55 net — within the 12h cap — so no warning may fire, even
+     * though the gross span (12:40) exceeds it.
+     */
+    public function testDayMaxHoursWarningUsesNetNotGross(): void {
+        $warnings = $this->service->dayWarnings([
+            $this->makeEntry('08:00', '20:40', 45),
+        ]);
+
+        $maxWarnings = array_filter(
+            $warnings,
+            static fn(string $w): bool => str_contains($w, 'Maximale tägliche Arbeitszeit')
+        );
+        $this->assertCount(
+            0,
+            $maxWarnings,
+            'Net time (11:55) is within the 12h cap; the gross span must not trigger the warning'
+        );
+    }
+
+    /**
+     * #437: When the NET working time actually exceeds the cap, the warning must
+     * still fire and report the net hours. 06:00–19:00 minus 45 min break =
+     * 12:15 net (12.25 h), which exceeds the 12h cap.
+     */
+    public function testDayMaxHoursWarningFiresOnNetExceedance(): void {
+        $warnings = $this->service->dayWarnings([
+            $this->makeEntry('06:00', '19:00', 45),
+        ]);
+
+        $maxWarnings = array_values(array_filter(
+            $warnings,
+            static fn(string $w): bool => str_contains($w, 'Maximale tägliche Arbeitszeit')
+        ));
+        $this->assertCount(1, $maxWarnings, 'Net 12:15 exceeds the 12h cap → warning expected');
+        $this->assertStringContainsString(
+            '12.25 Std. erfasst',
+            $maxWarnings[0],
+            'The warning must report NET hours (12.25), not gross (13)'
+        );
+    }
 }


### PR DESCRIPTION
## Problem
Die Tages-Warnung *„Maximale tägliche Arbeitszeit (10 Std.) überschritten"* verglich die **Brutto-Anwesenheit** (inkl. Pause) gegen das Limit. §3 ArbZG (und das Settings-Label) meint die **Netto-Arbeitszeit** (ohne Pause). Ein Eintrag mit **9:55 Netto** (08:30–19:10, 45 min Pause) löste die Warnung fälschlich aus.

Gemeldet von einer Kundin; RCA bestätigt in #437. Es ist derselbe Brutto/Netto-Fehler, der für die §4-Pausenprüfung bereits in #403 gefixt wurde.

## Fix
`TimeEntryService::dayWarnings()`: Prüfung auf **Netto = Brutto − Pause** umgestellt und Netto-Std. in der Meldung berichtet. Tote Variable `$grossHours` entfernt.

## Hinweis
Die Warnung ist und bleibt **non-blocking** (Report-Anzeige). Es gab nie eine harte Speicher-/Einreich-Sperre — die Kundin war technisch nicht blockiert, hat den roten Banner aber als solche gelesen.

## Tests
`tests/Unit/Service/TimeEntryServiceTest.php` — zwei ergebnis-orientierte Tests (Netto<Limit, Brutto>Limit → keine Warnung; Netto>Limit → Warnung mit Netto-Wert). **195 Tests grün** (PHPUnit im Container gegen ocp dev-master).

Fixes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGC7vd83NaXadHAH156rQ7