### PR TITLE
fix(absences): Jahresübergreifende Abwesenheiten korrekt behandeln (#439)

### DIFF
--- a/lib/Db/AbsenceMapper.php
+++ b/lib/Db/AbsenceMapper.php
@@ -55,18 +55,16 @@ class AbsenceMapper extends QBMapper {
      * @return Absence[]
      */
     public function findByEmployeeAndYear(int $employeeId, int $year): array {
+        // Overlap semantics: include every absence that TOUCHES the year, even
+        // when it starts in the previous year or ends in the next one (e.g. a
+        // Christmas→New Year vacation). A containment filter (start >= Jan 1 AND
+        // end <= Dec 31) silently dropped such absences from the personal list
+        // and the vacation balance (#439). The per-year day split is handled by
+        // AbsenceService::vacationDaysInYear().
         $startDate = new DateTime("$year-01-01");
         $endDate = new DateTime("$year-12-31");
 
-        $qb = $this->db->getQueryBuilder();
-        $qb->select('*')
-            ->from($this->getTableName())
-            ->where($qb->expr()->eq('employee_id', $qb->createNamedParameter($employeeId, IQueryBuilder::PARAM_INT)))
-            ->andWhere($qb->expr()->gte('start_date', $qb->createNamedParameter($startDate, IQueryBuilder::PARAM_DATE)))
-            ->andWhere($qb->expr()->lte('end_date', $qb->createNamedParameter($endDate, IQueryBuilder::PARAM_DATE)))
-            ->orderBy('start_date', 'ASC');
-
-        return $this->findEntities($qb);
+        return $this->findByEmployeeAndDateRange($employeeId, $startDate, $endDate);
     }
 
     /**
@@ -378,25 +376,5 @@ class AbsenceMapper extends QBMapper {
             ->orderBy('start_date', 'ASC');
 
         return $this->findEntities($qb);
-    }
-
-    public function sumVacationDaysByEmployeeAndYear(int $employeeId, int $year): float {
-        $startDate = new DateTime("$year-01-01");
-        $endDate = new DateTime("$year-12-31");
-
-        $qb = $this->db->getQueryBuilder();
-        $qb->select($qb->func()->sum('days'))
-            ->from($this->getTableName())
-            ->where($qb->expr()->eq('employee_id', $qb->createNamedParameter($employeeId, IQueryBuilder::PARAM_INT)))
-            ->andWhere($qb->expr()->eq('type', $qb->createNamedParameter(Absence::TYPE_VACATION)))
-            ->andWhere($qb->expr()->eq('status', $qb->createNamedParameter(Absence::STATUS_APPROVED)))
-            ->andWhere($qb->expr()->gte('start_date', $qb->createNamedParameter($startDate, IQueryBuilder::PARAM_DATE)))
-            ->andWhere($qb->expr()->lte('end_date', $qb->createNamedParameter($endDate, IQueryBuilder::PARAM_DATE)));
-
-        $result = $qb->executeQuery();
-        $sum = $result->fetchOne();
-        $result->closeCursor();
-
-        return (float)$sum;
     }
 }

--- a/lib/Service/AbsenceService.php
+++ b/lib/Service/AbsenceService.php
@@ -121,7 +121,7 @@ class AbsenceService {
         $days = $workingDays * $scope;
 
         if ($type === Absence::TYPE_VACATION) {
-            $this->checkVacationQuota($employeeId, $days, (int)$startDateObj->format('Y'));
+            $this->checkVacationQuota($employeeId, $startDateObj, $endDateObj, $federalState, $scope);
         }
 
         $isInformational = in_array($type, [Absence::TYPE_SICK, Absence::TYPE_CHILD_SICK], true);
@@ -230,7 +230,7 @@ class AbsenceService {
         $days = $workingDays * $scope;
 
         if ($type === Absence::TYPE_VACATION) {
-            $this->checkVacationQuota($absence->getEmployeeId(), $days, (int)$startDateObj->format('Y'), $id);
+            $this->checkVacationQuota($absence->getEmployeeId(), $startDateObj, $endDateObj, $federalState, $scope, $id);
         }
 
         $isInformational = in_array($type, [Absence::TYPE_SICK, Absence::TYPE_CHILD_SICK], true);
@@ -414,16 +414,21 @@ class AbsenceService {
      * Get vacation statistics for an employee in a given year
      */
     public function getVacationStats(int $employeeId, int $year, int $totalVacationDays): array {
-        $usedDays = $this->absenceMapper->sumVacationDaysByEmployeeAndYear($employeeId, $year);
-        $pendingAbsences = $this->absenceMapper->findByType($employeeId, Absence::TYPE_VACATION);
-        $pendingDays = 0;
+        $federalState = $this->employeeMapper->find($employeeId)->getFederalState();
 
-        foreach ($pendingAbsences as $absence) {
-            if ($absence->getStatus() === Absence::STATUS_PENDING) {
-                $absenceYear = (int)$absence->getStartDate()->format('Y');
-                if ($absenceYear === $year) {
-                    $pendingDays += (float)$absence->getDays();
-                }
+        // Overlap query + per-year day split (#439): a vacation spanning the year
+        // boundary is counted only with the portion that falls into this year.
+        $usedDays = 0.0;
+        $pendingDays = 0.0;
+        foreach ($this->absenceMapper->findByEmployeeAndYear($employeeId, $year) as $absence) {
+            if ($absence->getType() !== Absence::TYPE_VACATION) {
+                continue;
+            }
+            $daysInYear = $this->vacationDaysInYear($absence, $year, $federalState);
+            if ($absence->getStatus() === Absence::STATUS_APPROVED) {
+                $usedDays += $daysInYear;
+            } elseif ($absence->getStatus() === Absence::STATUS_PENDING) {
+                $pendingDays += $daysInYear;
             }
         }
 
@@ -469,6 +474,38 @@ class AbsenceService {
     }
 
     /**
+     * Vacation working days of an absence that fall WITHIN the given calendar year.
+     *
+     * This is the single source of truth for "how many vacation days does this
+     * absence count towards year X". For an absence fully contained in the year
+     * it is the stored `days`; for one spanning the year boundary (e.g. a
+     * Christmas→New Year vacation) only the clipped, in-year portion is counted —
+     * schedule- and holiday-aware — so the days are split across both years and
+     * never counted twice (#439). All per-year vacation counting must go through
+     * this method.
+     */
+    public function vacationDaysInYear(Absence $absence, int $year, string $federalState): float {
+        $yearStart = new DateTime("$year-01-01");
+        $yearEnd = new DateTime("$year-12-31");
+        $start = $absence->getStartDate();
+        $end = $absence->getEndDate();
+
+        // No overlap with the year at all.
+        if ($end < $yearStart || $start > $yearEnd) {
+            return 0.0;
+        }
+        // Fully within the year → the stored value already reflects it exactly.
+        if ($start >= $yearStart && $end <= $yearEnd) {
+            return (float)$absence->getDays();
+        }
+        // Spans the year boundary → count only the clipped, in-year working days.
+        $clipStart = $start < $yearStart ? $yearStart : $start;
+        $clipEnd = $end > $yearEnd ? $yearEnd : $end;
+        return $this->calculateWorkingDays($clipStart, $clipEnd, $federalState, $absence->getEmployeeId())
+            * $absence->getScopeValue();
+    }
+
+    /**
      * #360: A full-day absence is logically incompatible with time entries on the
      * same day — you cannot work and take the whole day off, and the overtime
      * would be counted twice (the absence consumes the daily target while the
@@ -511,35 +548,61 @@ class AbsenceService {
         ]);
     }
 
-    private function checkVacationQuota(int $employeeId, float $requestedDays, int $year, ?int $excludeId = null): void {
-        $employee = $this->employeeMapper->find($employeeId);
-        $totalVacationDays = (int)$employee->getVacationDays();
+    /**
+     * Enforce the yearly vacation quota for a new/edited absence. Checked per
+     * calendar year the request touches: a vacation spanning the year boundary
+     * consumes each year's quota only with its in-year portion (#439), so the
+     * quota is neither over- nor under-counted.
+     */
+    private function checkVacationQuota(
+        int $employeeId,
+        DateTime $startDate,
+        DateTime $endDate,
+        string $federalState,
+        float $scope,
+        ?int $excludeId = null
+    ): void {
+        $totalVacationDays = (float)$this->employeeMapper->find($employeeId)->getVacationDays();
 
-        // Sum all active (approved + pending) vacation days for the year, excluding the current record
-        $allVacations = $this->absenceMapper->findByEmployeeAndYear($employeeId, $year);
-        $usedDays = 0.0;
-        foreach ($allVacations as $absence) {
-            if ($absence->getType() !== Absence::TYPE_VACATION) {
-                continue;
-            }
-            if ($absence->getStatus() === Absence::STATUS_CANCELLED) {
-                continue;
-            }
-            if ($excludeId !== null && $absence->getId() === $excludeId) {
-                continue;
-            }
-            $usedDays += (float)$absence->getDays();
-        }
+        $startYear = (int)$startDate->format('Y');
+        $endYear = (int)$endDate->format('Y');
 
-        $remaining = $totalVacationDays - $usedDays;
-        if ($requestedDays > $remaining) {
-            throw new ValidationException([
-                'vacationQuota' => [sprintf(
-                    'Not enough vacation days. Available: %.1f, requested: %.1f.',
-                    max(0, $remaining),
-                    $requestedDays
-                )],
-            ]);
+        for ($year = $startYear; $year <= $endYear; $year++) {
+            $yearStart = new DateTime("$year-01-01");
+            $yearEnd = new DateTime("$year-12-31");
+            $clipStart = $startDate < $yearStart ? $yearStart : $startDate;
+            $clipEnd = $endDate > $yearEnd ? $yearEnd : $endDate;
+
+            $requestedInYear = $this->calculateWorkingDays($clipStart, $clipEnd, $federalState, $employeeId) * $scope;
+            if ($requestedInYear <= 0) {
+                continue;
+            }
+
+            // Already-used in-year days (approved + pending, excluding this record).
+            $usedDays = 0.0;
+            foreach ($this->absenceMapper->findByEmployeeAndYear($employeeId, $year) as $absence) {
+                if ($absence->getType() !== Absence::TYPE_VACATION) {
+                    continue;
+                }
+                if ($absence->getStatus() === Absence::STATUS_CANCELLED) {
+                    continue;
+                }
+                if ($excludeId !== null && $absence->getId() === $excludeId) {
+                    continue;
+                }
+                $usedDays += $this->vacationDaysInYear($absence, $year, $federalState);
+            }
+
+            $remaining = $totalVacationDays - $usedDays;
+            if ($requestedInYear > $remaining) {
+                throw new ValidationException([
+                    'vacationQuota' => [sprintf(
+                        'Not enough vacation days. Available: %.1f, requested: %.1f.',
+                        max(0, $remaining),
+                        $requestedInYear
+                    )],
+                ]);
+            }
         }
     }
 

--- a/tests/Unit/Service/AbsenceServiceTest.php
+++ b/tests/Unit/Service/AbsenceServiceTest.php
@@ -398,4 +398,83 @@ class AbsenceServiceTest extends TestCase {
         $this->assertSame([Absence::STATUS_APPROVED], $statuses);
         $this->assertNotContains(Absence::STATUS_PENDING, $statuses);
     }
+
+    // ---------------------------------------------------------------------
+    // #439: Jahresübergreifende Abwesenheiten — anteilige Zählung pro Jahr
+    // ---------------------------------------------------------------------
+
+    public function testVacationDaysInYearFullyWithinReturnsStoredDays(): void {
+        $absence = $this->makeAbsence(
+            Absence::TYPE_VACATION,
+            Absence::STATUS_APPROVED,
+            new DateTime('2026-06-10'),
+            new DateTime('2026-06-12')
+        );
+        $absence->setDays('3.00');
+
+        // Fully inside the year → returns the stored value, no recomputation.
+        $this->assertSame(3.0, $this->service->vacationDaysInYear($absence, 2026, 'BW'));
+    }
+
+    public function testVacationDaysInYearNoOverlapReturnsZero(): void {
+        $absence = $this->makeAbsence(
+            Absence::TYPE_VACATION,
+            Absence::STATUS_APPROVED,
+            new DateTime('2025-06-10'),
+            new DateTime('2025-06-12')
+        );
+        $absence->setDays('3.00');
+
+        $this->assertSame(0.0, $this->service->vacationDaysInYear($absence, 2026, 'BW'));
+    }
+
+    public function testVacationDaysInYearSpanningCountsOnlyInYearPortion(): void {
+        // Christmas → New Year vacation: 3 working days in 2025, 1 in 2026.
+        $this->holidayMapper->method('findHolidaysInRange')->willReturn([]);
+        $this->workScheduleService->method('countWorkingDays')->willReturnCallback(
+            static fn(int $empId, DateTime $start, DateTime $end, array $holidays): float
+                => $start->format('Y') === '2025' ? 3.0 : 1.0
+        );
+
+        $absence = $this->makeAbsence(
+            Absence::TYPE_VACATION,
+            Absence::STATUS_APPROVED,
+            new DateTime('2025-12-29'),
+            new DateTime('2026-01-02')
+        );
+        // Stored total days (4) must be IGNORED for the spanning case — each year
+        // gets only its clipped portion, so no double counting across the two years.
+        $absence->setDays('4.00');
+
+        $this->assertSame(3.0, $this->service->vacationDaysInYear($absence, 2025, 'BW'));
+        $this->assertSame(1.0, $this->service->vacationDaysInYear($absence, 2026, 'BW'));
+    }
+
+    public function testGetVacationStatsDeductsOnlyInYearPortionOfSpanningVacation(): void {
+        $employee = new \OCA\WorkTime\Db\Employee();
+        $employee->setFederalState('BW');
+        $this->employeeMapper->method('find')->with(1)->willReturn($employee);
+
+        $this->holidayMapper->method('findHolidaysInRange')->willReturn([]);
+        $this->workScheduleService->method('countWorkingDays')->willReturnCallback(
+            static fn(int $empId, DateTime $start, DateTime $end, array $holidays): float
+                => $start->format('Y') === '2025' ? 3.0 : 1.0
+        );
+
+        $spanning = $this->makeAbsence(
+            Absence::TYPE_VACATION,
+            Absence::STATUS_APPROVED,
+            new DateTime('2025-12-29'),
+            new DateTime('2026-01-02')
+        );
+        $spanning->setDays('4.00');
+        // The year query (overlap) surfaces the spanning absence for 2025.
+        $this->absenceMapper->method('findByEmployeeAndYear')->with(1, 2025)->willReturn([$spanning]);
+
+        $stats = $this->service->getVacationStats(1, 2025, 30);
+
+        // Only the 3 in-year days count against 2025, not the full 4.
+        $this->assertSame(3.0, $stats['used']);
+        $this->assertSame(27.0, $stats['remaining']);
+    }
 }


### PR DESCRIPTION
## Problem
Ein Urlaub über den Jahreswechsel (z. B. Weihnachtsurlaub 28.12.–02.01.) erschien in der **Team-Ansicht**, aber **nicht** in „Meine Abwesenheiten", und wurde **nicht vom Urlaub abgezogen**. Ursache: persönliche Liste, Saldo und Quota filterten per **Containment** (`start ≥ 1.Jan AND end ≤ 31.Dez`) → jahresübergreifende Einträge fielen aus **beiden** Jahren; die Team-Ansicht nutzt **Overlap**. RCA in #439.

## Fix — Option A (ein Eintrag bleibt ein Eintrag)
Bewusst *kein* Split in zwei Datensätze (das würde Storno/Bearbeiten fragmentieren und ist bei häufigem Weihnachtsurlaub für alle unpraktisch). Stattdessen:

- `AbsenceMapper::findByEmployeeAndYear` → **Overlap** (delegiert an `findByEmployeeAndDateRange`). `findByEmployeeIdsAndYear` war bereits Overlap.
- Neuer zentraler Helfer **`AbsenceService::vacationDaysInYear()`** als *einzige* Quelle für „Urlaubstage im Jahr X": ganz im Jahr → gespeicherte `days`; über den Jahreswechsel → nur der aufs Jahr zugeschnittene, schedule-/feiertagsbewusste Anteil. **Keine Doppelzählung.**
- `getVacationStats` (Saldo) und `checkVacationQuota` laufen durch den Helfer; Quota wird **pro berührtem Jahr** geprüft.
- Buggy `sumVacationDaysByEmployeeAndYear` (Containment-SQL-SUM) entfernt.

## Ergebnis
Ein Weihnachtsurlaub ist wieder in „Meine Abwesenheiten" sichtbar, wird tagegenau auf beide Jahre verteilt abgezogen und bleibt **ein** Eintrag (einmal anlegen/stornieren/bearbeiten).

## Tests
4 neue ergebnis-orientierte Unit-Tests (`vacationDaysInYear`: innerhalb/kein-Überlapp/spanning; `getVacationStats`: anteiliger Abzug). **197 Tests grün** (PHPUnit im Container).

Kein Migrations-/Datenmodell-/Frontend-Eingriff.

Fixes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGC7vd83NaXadHAH156rQ7