### PR TITLE
ci(review): git fetch in Release-Review-Allowlist + Fleet-Sync

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -211,4 +211,4 @@ jobs:
             NEEDS_FIX nur bei echten Release-Blockern (fehlende Migration, falscher CHANGELOG/Version, Reste, Integrationskonflikt).
           claude_args: |
             --max-turns 40
-            --allowedTools "Glob,Grep,LS,Read,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(cat:*),Bash(ls:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),mcp__github_comment__update_claude_comment"
+            --allowedTools "Glob,Grep,LS,Read,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(git fetch:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(cat:*),Bash(ls:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),mcp__github_comment__update_claude_comment"


### PR DESCRIPTION
## Problem

Der Release-Review-Job (`release/*`-PRs) stürzte ab: Er versucht `git fetch origin main`, aber `Bash(git fetch:*)` fehlte in seiner Allowlist — der Feature-Review-Job hatte es (aus #451), der Release-Job nicht. Der Bot kam nie zum Review, postete keinen Kommentar (an worktime v0.13.0 / PR #462 beobachtet).

## Fix

`Bash(git fetch:*)` in die Allowlist des Release-Review-Jobs ergänzt. Damit ist der Workflow außerdem **fleet-weit auf einen identischen Stand** gebracht (contractmanager, rechnungswerk, vinarium, worktime → gleiche Datei, gleicher md5) — beendet die Drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9oB39x3emtJh9wsZmZKra
