### PR TITLE
ci(review): Claude-Review fuer Dependabot-PRs ueberspringen

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,8 +6,22 @@ on:
 
 jobs:
   claude-review:
-    # Only review non-draft PRs
-    if: github.event.pull_request.draft == false
+    # Nur nicht-Draft-PRs reviewen.
+    #
+    # Dependabot-PRs ausgenommen (19.07.2026): GitHub reicht regulaere
+    # Actions-Secrets bei dependabot-getriggerten Laeufen bewusst NICHT durch —
+    # Dependabot-PRs werden von Inhalten fremder Pakete beeinflusst. Das Review
+    # scheiterte dort deshalb dauerhaft an einem leeren
+    # CLAUDE_CODE_OAUTH_TOKEN. Das Token als Dependabot-Secret zu hinterlegen
+    # waere moeglich, wuerde aber genau diese Schutzmassnahme aushebeln — fuer
+    # einen Nutzen nahe null, weil ein Versionsbump in package-lock.json nichts
+    # hergibt, was die Test-Jobs nicht schon abdecken. Die laufen weiter.
+    #
+    # Bewusst ueber user.login statt github.actor: bei einem Rerun waere actor
+    # der Mensch, der neu gestartet hat, nicht der PR-Autor.
+    if: |
+      github.event.pull_request.draft == false
+      && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -92,9 +106,9 @@ jobs:
           # Alternative: anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Erlaubt Claude Bot als Trigger (wenn claude.yml PRs erstellt/pusht).
-          # dependabot[bot] MUSS mit drin sein, sonst bricht die Action bei jedem
-          # Dependabot-PR mit "Workflow initiated by non-human actor" ab und der
-          # PR bleibt dauerhaft ungereviewt (aufgefallen an #482, 16.07.2026).
+          # dependabot[bot] bleibt gelistet, obwohl der Job fuer Dependabot-PRs
+          # oben gar nicht mehr startet: schadet nicht und haelt fest, dass der
+          # Fall geprueft wurde (siehe Job-Kommentar).
           allowed_bots: "claude[bot],github-actions[bot],dependabot[bot]"
           show_full_output: true
           prompt: |


### PR DESCRIPTION
## Problem

Der Claude-Review scheiterte bei Dependabot-PRs dauerhaft. Die Ursachenkette, Schritt fuer Schritt freigelegt:

| # | Fehler | Status |
|---|---|---|
| 1 | `allowed_bots` ohne `dependabot[bot]` → *"Workflow initiated by non-human actor"* | behoben (#488/#489) |
| 2 | Dependabot-Branch aelter als der Fix → stiller Skip | behoben per `@dependabot rebase` |
| 3 | **`CLAUDE_CODE_OAUTH_TOKEN` leer** → *"Environment variable validation failed"* | dieser PR |

## Warum nicht einfach das Secret hinterlegen

Punkt 3 ist keine Fehlkonfiguration. GitHub reicht regulaere Actions-Secrets bei dependabot-getriggerten Laeufen **absichtlich nicht** durch, weil Dependabot-PRs von Inhalten fremder Pakete beeinflusst werden.

Man koennte das Token als Dependabot-Secret hinterlegen. Das wuerde aber genau diese Schutzmassnahme aushebeln — fuer einen Nutzen nahe null: Ein Versionsbump in `package-lock.json` gibt nichts her, was `phpunit`, `node` und `canary` nicht schon abdecken. Die Angriffsflaeche zu vergroessern lohnt dafuer nicht.

## Loesung

Der Review-Job startet fuer Dependabot-PRs gar nicht mehr. Der Check ist damit sauber uebersprungen statt dauerhaft rot, und die Fehlschlag-Benachrichtigungen hoeren auf. **Die Test-Jobs laufen unveraendert weiter** — Dependabot-PRs bleiben also abgesichert, nur eben durch Tests statt durch ein Code-Review.

## Details

- Bedingung ueber `pull_request.user.login` statt `github.actor`: Bei einem Rerun waere `actor` der Mensch, der neu gestartet hat, nicht der PR-Autor.
- `dependabot[bot]` bleibt in `allowed_bots` gelistet, obwohl der Job nicht mehr startet — schadet nicht und haelt fest, dass der Fall geprueft wurde.
- YAML gegen PyYAML validiert.

## Wichtig beim Merge

Wieder **paarweise nach `develop` und `main`**, sonst validiert die Action gegen einen abweichenden Default-Branch und ueberspringt Reviews still.