### PR TITLE
fix(absences): Jahresübertrag in der Antrags-Quotenprüfung berücksichtigen (#500)

### DIFF
--- a/lib/Service/AbsenceService.php
+++ b/lib/Service/AbsenceService.php
@@ -44,6 +44,7 @@ class AbsenceService {
         private NotificationService $notificationService,
         private WorkScheduleService $workScheduleService,
         private HolidayService $holidayService,
+        private YearlyCarryoverService $carryoverService,
         private LoggerInterface $logger,
         private IL10N $l,
     ) {
@@ -1030,9 +1031,17 @@ class AbsenceService {
      * Remaining vacation days of one calendar year: quota minus the in-year
      * portion of all approved + pending vacation entries (#439). May be
      * negative after an OVERAGE_NEGATIVE booking (#15 Stufe 2).
+     *
+     * #500: the quota must match the figure the employee sees. The overview
+     * (AbsenceController::vacationStats) adds the previous-year carryover on top
+     * of the base entitlement; the quota check ignored it, so a request the
+     * overview showed as covered was rejected. Add the carryover, rounded the
+     * same way the overview rounds it.
      */
     private function remainingVacationDays(int $employeeId, int $year, string $federalState, ?int $excludeId = null): float {
-        $totalVacationDays = (float)$this->employeeMapper->find($employeeId)->getVacationDays();
+        $baseEntitlement = (float)$this->employeeMapper->find($employeeId)->getVacationDays();
+        $carryover = $this->carryoverService->getVacationCarryoverDays($employeeId, $year);
+        $totalVacationDays = $baseEntitlement + (float)(int)round($carryover);
 
         $usedDays = 0.0;
         foreach ($this->absenceMapper->findByEmployeeAndYear($employeeId, $year) as $absence) {

--- a/tests/Unit/Service/AbsenceServiceTest.php
+++ b/tests/Unit/Service/AbsenceServiceTest.php
@@ -22,6 +22,7 @@ use OCA\WorkTime\Service\ProjectService;
 use OCA\WorkTime\Service\TimeEntryService;
 use OCA\WorkTime\Service\ValidationException;
 use OCA\WorkTime\Service\WorkScheduleService;
+use OCA\WorkTime\Service\YearlyCarryoverService;
 use OCP\IL10N;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -46,6 +47,7 @@ class AbsenceServiceTest extends TestCase {
     private NotificationService $notificationService;
     private WorkScheduleService $workScheduleService;
     private HolidayService $holidayService;
+    private YearlyCarryoverService $carryoverService;
     private LoggerInterface $logger;
     private IL10N $l;
 
@@ -58,6 +60,7 @@ class AbsenceServiceTest extends TestCase {
         $this->notificationService = $this->createMock(NotificationService::class);
         $this->workScheduleService = $this->createMock(WorkScheduleService::class);
         $this->holidayService = $this->createMock(HolidayService::class);
+        $this->carryoverService = $this->createMock(YearlyCarryoverService::class);
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->l = $this->createMock(IL10N::class);
         $this->l->method('t')->willReturnCallback(
@@ -90,6 +93,7 @@ class AbsenceServiceTest extends TestCase {
             $this->notificationService,
             $this->workScheduleService,
             $this->holidayService,
+            $this->carryoverService,
             $this->logger,
             $this->l
         );
@@ -1011,6 +1015,41 @@ class AbsenceServiceTest extends TestCase {
             ->willReturn([$this->vacation(Absence::STATUS_APPROVED, '2026-03-02', '2026-03-06', '5.00')]);
 
         $this->assertSame(25.0, $this->remaining(2026));
+    }
+
+    // ---------------------------------------------------------------------
+    // #500: the request-time quota must include the previous-year carryover,
+    // exactly like the overview the employee sees. Without it a request the
+    // overview shows as covered was wrongly rejected.
+    // ---------------------------------------------------------------------
+
+    public function testRemainingVacationIncludesCarryover(): void {
+        // Reporter's case: 30 base + 16 carryover − 27 approved = 19 remaining.
+        // The buggy code returned 30 − 27 = 3 and blocked the request.
+        $emp = new Employee();
+        $emp->setId(1);
+        $emp->setVacationDays(30);
+        $this->employeeMapper->method('find')->willReturn($emp);
+        $this->carryoverService->method('getVacationCarryoverDays')->willReturn(16.0);
+        $this->absenceMapper->method('findByEmployeeAndYear')
+            ->willReturn([$this->vacation(Absence::STATUS_APPROVED, '2026-01-05', '2026-02-10', '27.00')]);
+
+        $this->assertSame(19.0, $this->remaining(2026));
+    }
+
+    public function testRemainingVacationRoundsCarryoverLikeOverview(): void {
+        // The overview rounds the carryover to a whole day before showing it
+        // (AbsenceController::vacationStats). The quota must round identically,
+        // otherwise the block and the displayed number disagree again.
+        $emp = new Employee();
+        $emp->setId(1);
+        $emp->setVacationDays(30);
+        $this->employeeMapper->method('find')->willReturn($emp);
+        $this->carryoverService->method('getVacationCarryoverDays')->willReturn(15.5);
+        $this->absenceMapper->method('findByEmployeeAndYear')->willReturn([]);
+
+        // 30 + round(15.5) = 30 + 16 = 46, nothing used.
+        $this->assertSame(46.0, $this->remaining(2026));
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Beim Beantragen von Urlaub prüft WorkTime `requested 6 / available 3` und lehnt ab, obwohl die Urlaubsübersicht 19 verfügbare Tage zeigt (Meldung #500).

**Ursache:** Zwei Rechenpfade für die verfügbaren Urlaubstage liefen auseinander:

| | Basis | Übertrag | Ergebnis |
|---|---|---|---|
| Übersicht (`AbsenceController::vacationStats`) | 30 | +16 | 46 − 27 = **19** |
| Antragssperre (`AbsenceService::remainingVacationDays`) | 30 | **fehlt** | 30 − 27 = **3** |

Die Antragssperre kannte den `YearlyCarryoverService` gar nicht.

## Fix

- `YearlyCarryoverService` in `AbsenceService` injiziert
- `remainingVacationDays()` addiert den Jahresübertrag, mit derselben Rundung wie die Übersicht

Minimal-invasiv: nur der fehlende Übertrag. Ein zweiter, latenter Widerspruch (Basis-Anspruch aus `employee.vacation_days` vs. schedule-aware `getVacationDaysForYear()`) wurde bewusst NICHT gebündelt, weil er auch die Betriebsferien-Buchung ändert → **#501**.

## Tests

- Rot→grün-Regressionstest mit exaktem Reporter-Szenario (ohne Fix: 3, mit Fix: 19)
- Rundungstest (Übertrag 15,5 → +16, wie die Übersicht)
- Volle Suite grün: 260 Tests (vorher 258)
- Live gegen die lokale Instanz geprüft: DI-Verdrahtung + echter DB-Read (30 + 16 − 10 genommen = 36)

Fixes #500