### PR TITLE
fix(absences): Urlaubs-Kontingentprüfung nutzt den jahresgenauen Anspruch (#501)

### DIFF
--- a/lib/Service/AbsenceService.php
+++ b/lib/Service/AbsenceService.php
@@ -1032,14 +1032,20 @@ class AbsenceService {
      * portion of all approved + pending vacation entries (#439). May be
      * negative after an OVERAGE_NEGATIVE booking (#15 Stufe 2).
      *
-     * #500: the quota must match the figure the employee sees. The overview
-     * (AbsenceController::vacationStats) adds the previous-year carryover on top
-     * of the base entitlement; the quota check ignored it, so a request the
-     * overview showed as covered was rejected. Add the carryover, rounded the
-     * same way the overview rounds it.
+     * The quota must match the figure the employee sees, built in
+     * AbsenceController::vacationStats() as schedule-aware base entitlement plus
+     * previous-year carryover:
+     *  - #500: add the carryover, rounded the same way the overview rounds it.
+     *  - #501: take the base from the year's own work-schedule profile
+     *    (getVacationDaysForYear) instead of the employee cache field. The cache
+     *    only ever holds today's profile, so checking a past year with a
+     *    different profile — or a year whose future-dated profile has not yet
+     *    synced the cache — used the wrong base while the overview showed the
+     *    right one. This is the single point both remainingVacationDays callers
+     *    (checkVacationQuota and the Betriebsferien splitPeriod) share.
      */
     private function remainingVacationDays(int $employeeId, int $year, string $federalState, ?int $excludeId = null): float {
-        $baseEntitlement = (float)$this->employeeMapper->find($employeeId)->getVacationDays();
+        $baseEntitlement = (float)$this->workScheduleService->getVacationDaysForYear($employeeId, $year);
         $carryover = $this->carryoverService->getVacationCarryoverDays($employeeId, $year);
         $totalVacationDays = $baseEntitlement + (float)(int)round($carryover);
 

--- a/tests/Unit/Service/AbsenceServiceTest.php
+++ b/tests/Unit/Service/AbsenceServiceTest.php
@@ -48,6 +48,8 @@ class AbsenceServiceTest extends TestCase {
     private WorkScheduleService $workScheduleService;
     private HolidayService $holidayService;
     private YearlyCarryoverService $carryoverService;
+    /** @var array<int,int> Per-year override for getVacationDaysForYear (#501). */
+    private array $scheduleEntitlementByYear = [];
     private LoggerInterface $logger;
     private IL10N $l;
 
@@ -96,6 +98,18 @@ class AbsenceServiceTest extends TestCase {
             $this->carryoverService,
             $this->logger,
             $this->l
+        );
+
+        // #501: remainingVacationDays() now takes the base entitlement from the
+        // year's work-schedule profile (getVacationDaysForYear), not the employee
+        // cache field. Every existing test was written under the invariant that
+        // the two are equal, so mirror the employee's cached vacation_days here.
+        // A test that needs a genuine year-over-year divergence fills
+        // $scheduleEntitlementByYear[$year] to override a single year.
+        $this->scheduleEntitlementByYear = [];
+        $this->workScheduleService->method('getVacationDaysForYear')->willReturnCallback(
+            fn(int $employeeId, int $year): int => $this->scheduleEntitlementByYear[$year]
+                ?? $this->employeeMapper->find($employeeId)->getVacationDays()
         );
     }
 
@@ -1050,6 +1064,23 @@ class AbsenceServiceTest extends TestCase {
 
         // 30 + round(15.5) = 30 + 16 = 46, nothing used.
         $this->assertSame(46.0, $this->remaining(2026));
+    }
+
+    public function testRemainingVacationUsesTheYearsOwnEntitlement(): void {
+        // #501: the employee's cache field holds today's profile (30), but in
+        // 2024 the profile granted only 20 days. The quota for a 2024 request
+        // must use 20 — the same figure the overview shows for 2024 — not the
+        // cached 30. The buggy code returned 30 and would wave through requests
+        // the overview shows as over budget.
+        $emp = new Employee();
+        $emp->setId(1);
+        $emp->setVacationDays(30); // cache = today's profile
+        $this->employeeMapper->method('find')->willReturn($emp);
+        // In 2024 the profile granted only 20 days, unlike today's cached 30.
+        $this->scheduleEntitlementByYear = [2024 => 20];
+        $this->absenceMapper->method('findByEmployeeAndYear')->willReturn([]);
+
+        $this->assertSame(20.0, $this->remaining(2024));
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`AbsenceService::remainingVacationDays` (Antragssperre **und** Betriebsferien-Buchung) las den Grundanspruch aus `employee.vacation_days` — einem **Cache des heute gültigen** Arbeitszeitprofils. Übersicht und Reports nutzen dagegen den **jahresgenauen** Wert (`getVacationDaysForYear`).

Zwei reale Divergenzen, die die **Buchung** treffen (nicht nur die Anzeige):
1. **Jahres-Ignoranz:** Antrag/Betriebsferien für ein Vorjahr mit anderem Profil wird gegen das falsche (heutige) Kontingent geprüft.
2. **Stale-Cache:** zukunftsdatiertes Profil mit anderem Anspruch → Cache bleibt veraltet, Anzeige und Buchung laufen schon im laufenden Jahr auseinander.

Aufgefallen bei der RCA zu #500.

## Fix

Basis in `remainingVacationDays` auf `getVacationDaysForYear($employeeId, $year)` umgestellt. **Ein Engpass**, beide Aufrufer (`checkVacationQuota` + Betriebsferien `splitPeriod`) werden jahres-korrekt; kein weiterer Pfad betroffen. Zusammen mit dem Carryover aus #500 rechnen Buchung, Übersicht und Reports jetzt überall aus derselben Quelle.

Profillose Mitarbeiter unkritisch: `getScheduleForDate`-Fallback = 30, identisch zum Default des Cache-Felds.

## Blast-Radius (geprüft)

- Nur zwei Aufrufer, beide gewollte Ziele. Im Normalfall (gleichbleibender Anspruch, laufendes Jahr) **null Verhaltensänderung**.
- Keine Migration, keine Daten-Rewrites — reine Laufzeitprüfung.
- Eine zusätzliche DB-Abfrage pro geprüftem Jahr (in Betriebsferien pro Jahr gecacht); die Anzeige macht dieselbe ohnehin.

## Tests

- Volle Suite grün: **261 Tests** (vorher 260)
- Die vorhandenen AbsenceService-Tests wurden unter der Invariante "Profil-Anspruch == Cache" geschrieben; `setUp` spiegelt das nun treu aus dem Mitarbeiter-Mock (keine kaschierte Verhaltensänderung — geprüft, kein Test kodiert per-Jahr abweichenden Anspruch)
- Neuer rot→grün-Test für echte Jahres-Divergenz (2024 = 20 vs. Cache 30)
- Live gegen die Instanz: `remaining(6, 2024) = 20` (Jahresprofil) statt 30 (Cache)

Fixes #501