### PR TITLE
fix(migration): deputy_id auf Instanzen mit vorregistrierter V21 nachtragen

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -44,7 +44,7 @@ Gesetzeskonforme Arbeitszeiterfassung für kleine Unternehmen in Deutschland.
 Behalten Sie den Überblick über Arbeitszeiten, Überstunden und Urlaub.
     ]]></description>
 
-    <version>0.15.1</version>
+    <version>0.15.2</version>
     <licence>AGPL-3.0-or-later</licence>
 
     <author mail="axel.deffner@cpcmomentum.com" homepage="https://github.com/cpcMomentum">Axel Deffner</author>

--- a/lib/Migration/Version000023Date20260724000000.php
+++ b/lib/Migration/Version000023Date20260724000000.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Axel Deffner <axel@cpcmomentum.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Repariert Instanzen, auf denen Version000021 in oc_migrations als angewendet
+ * registriert war, ohne dass wt_employees.deputy_id angelegt wurde. Auf solchen
+ * Instanzen fuehrt Nextcloud Version000021 nie wieder aus, weil die Versions-
+ * kennung bereits abgehakt ist. Diese Migration traegt deshalb dieselbe Spalte
+ * samt Index unter einer neuen Versionsnummer nach.
+ *
+ * Idempotent: auf korrekten Instanzen (Spalte und Index existieren bereits) ein
+ * No-Op. Siehe #343 fuer die urspruengliche Einfuehrung von deputy_id.
+ */
+class Version000023Date20260724000000 extends SimpleMigrationStep {
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('wt_employees');
+
+		if (!$table->hasColumn('deputy_id')) {
+			$table->addColumn('deputy_id', Types::INTEGER, [
+				'notnull' => false,
+			]);
+		}
+
+		if (!$table->hasIndex('wt_emp_deputy_idx')) {
+			$table->addIndex(['deputy_id'], 'wt_emp_deputy_idx');
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
## Problem
`GET /apps/worktime/` wirft auf `nc.bedethi.com` (NC 34, worktime 0.15.1) einen 500er:

```
SQLSTATE[42703]: Undefined column: column "deputy_id" does not exist
SELECT * FROM "oc_wt_employees" WHERE ("deputy_id" = $1)
```

Aufrufkette: `PageController::index` → `PermissionService::hasActiveDeputyApprovals` → `findByDeputy` → `EmployeeMapper::findEntities`.

## Ursache (verifiziert)
Die Spalte `deputy_id` fehlt, obwohl `Version000021` in `oc_migrations` als angewendet registriert ist. Git-Analyse belegt: V21 wurde **nie nachträglich editiert** — sie kam am 17.07 komplett mit `deputy_id` (in v0.15.0 und v0.15.1). Beim heutigen Upgrade 0.14.0 → 0.15.1 lief V22 (`locked_reason`), V21 aber nicht. Die konsistente Erklärung: V21 war auf der Instanz bereits als angewendet eingetragen und wurde daher übersprungen; Nextcloud führt sie nie wieder aus, weil die Versionsnummer abgehakt ist.

## Fix
Neue idempotente `Version000023`, die `deputy_id` samt Index `wt_emp_deputy_idx` unter neuer Nummer nachträgt. V21 bleibt unangetastet (ein Edit erreicht betroffene Instanzen nicht). Auf korrekten/frischen Instanzen ein No-Op dank `hasColumn`/`hasIndex`-Guard.

## Test (rot→grün, lokale Docker-Instanz NC 34 / PostgreSQL 16)
- **Rot:** `deputy_id` gedroppt, V21 blieb registriert (bedethi-Zustand nachgestellt).
- **Grün:** `occ upgrade` → Spalte (integer, nullable) + Index wiederhergestellt, V23 registriert.
- **Idempotent:** zweiter Lauf ohne Fehler.
- **End-to-End:** vorher crashende Abfrage (`WHERE deputy_id IS NULL`) liest wieder.

Nebenbefund: lokal fehlte sogar nur der Index (Spalte war da) — V23 repariert auch diesen Teilzustand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)