### PR TITLE
fix(api): Mitarbeiter darf eigenes Arbeitszeitprofil lesen (#526)

### DIFF
--- a/lib/Controller/WorkScheduleController.php
+++ b/lib/Controller/WorkScheduleController.php
@@ -26,13 +26,27 @@ class WorkScheduleController extends BaseController {
         parent::__construct($request, $userId);
     }
 
+    /**
+     * #526: Lesen ist bewusst schwaecher geschuetzt als Schreiben. Vorher stand
+     * hier canManageEmployees() — dieselbe Huerde wie fuer create/update/destroy
+     * weiter unten. Damit kam ein Mitarbeiter nicht einmal an sein EIGENES
+     * Arbeitszeitprofil, weil die eigene Mitarbeiter-ID in der Pruefung gar
+     * nicht vorkam. In der Weboberflaeche faellt das nie auf: der Profil-Editor
+     * haengt im Mitarbeiter-Formular, das ohnehin nur Admin/HR erreichen. Ueber
+     * die API war es ein harter Blocker.
+     *
+     * canViewEmployee() deckt die drei sinnvollen Faelle ab (Admin/HR, eigene
+     * Daten, Unterstellte) und ist das, was vergleichbare Lese-Endpunkte
+     * ohnehin verwenden — AbsenceController::vacationStats() etwa.
+     * Schreibend bleibt es bei canManageEmployees().
+     */
     #[NoAdminRequired]
     public function index(int $employeeId): JSONResponse {
         if ($authError = $this->requireAuth()) {
             return $authError;
         }
 
-        if (!$this->permissionService->canManageEmployees($this->userId)) {
+        if (!$this->permissionService->canViewEmployee($this->userId, $employeeId)) {
             return $this->forbiddenResponse();
         }
 

--- a/tests/Unit/Controller/WorkScheduleControllerTest.php
+++ b/tests/Unit/Controller/WorkScheduleControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Tests\Unit\Controller;
+
+use OCA\WorkTime\Controller\WorkScheduleController;
+use OCA\WorkTime\Service\PermissionService;
+use OCA\WorkTime\Service\WorkScheduleService;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #526: Lesen des Arbeitszeitprofils war an canManageEmployees() gebunden — der
+ * gleichen Huerde wie Anlegen, Aendern und Loeschen. Ein Mitarbeiter kam damit
+ * nicht an sein eigenes Profil. Diese Tests nageln die Rollentrennung fest:
+ * lesen darf, wer den Mitarbeiter sehen darf; schreiben nur die Verwaltung.
+ */
+class WorkScheduleControllerTest extends TestCase {
+
+    private WorkScheduleService $workScheduleService;
+    private PermissionService $permissionService;
+
+    protected function setUp(): void {
+        $this->workScheduleService = $this->createMock(WorkScheduleService::class);
+        $this->permissionService = $this->createMock(PermissionService::class);
+    }
+
+    private function makeController(string $userId = 'employee'): WorkScheduleController {
+        return new WorkScheduleController(
+            $this->createMock(IRequest::class),
+            $userId,
+            $this->workScheduleService,
+            $this->permissionService,
+        );
+    }
+
+    /**
+     * Der gemeldete Fall: eigene Mitarbeiter-ID, kein Verwaltungsrecht.
+     */
+    public function testEmployeeMayReadOwnSchedule(): void {
+        $this->permissionService->method('canViewEmployee')->with('employee', 3)->willReturn(true);
+        $this->permissionService->method('canManageEmployees')->willReturn(false);
+        $this->workScheduleService->method('findByEmployee')->with(3)->willReturn([]);
+
+        $this->assertSame(200, $this->makeController()->index(3)->getStatus());
+    }
+
+    /**
+     * Gegenprobe: fremder Mitarbeiter bleibt gesperrt. Die Lockerung darf nicht
+     * zum Freibrief auf alle Profile werden.
+     */
+    public function testEmployeeMayNotReadForeignSchedule(): void {
+        $this->permissionService->method('canViewEmployee')->with('employee', 99)->willReturn(false);
+        $this->permissionService->method('canManageEmployees')->willReturn(false);
+        $this->workScheduleService->expects($this->never())->method('findByEmployee');
+
+        $this->assertSame(403, $this->makeController()->index(99)->getStatus());
+    }
+
+    /**
+     * Vorgesetzte und Verwaltung kommen ueber dieselbe Pruefung herein.
+     */
+    public function testSupervisorMayReadSubordinateSchedule(): void {
+        $this->permissionService->method('canViewEmployee')->with('supervisor', 3)->willReturn(true);
+        $this->permissionService->method('canManageEmployees')->willReturn(false);
+        $this->workScheduleService->method('findByEmployee')->with(3)->willReturn([]);
+
+        $this->assertSame(200, $this->makeController('supervisor')->index(3)->getStatus());
+    }
+
+    /**
+     * Schreiben bleibt der Verwaltung vorbehalten — auch fuer das eigene Profil.
+     */
+    public function testEmployeeMayNotCreateOwnSchedule(): void {
+        $this->permissionService->method('canViewEmployee')->willReturn(true);
+        $this->permissionService->method('canManageEmployees')->willReturn(false);
+        $this->workScheduleService->expects($this->never())->method('create');
+
+        $this->assertSame(403, $this->makeController()->create(3, '2026-01-01')->getStatus());
+    }
+
+    public function testEmployeeMayNotUpdateOwnSchedule(): void {
+        $this->permissionService->method('canViewEmployee')->willReturn(true);
+        $this->permissionService->method('canManageEmployees')->willReturn(false);
+        $this->workScheduleService->expects($this->never())->method('update');
+
+        $this->assertSame(403, $this->makeController()->update(3, 5)->getStatus());
+    }
+
+    public function testEmployeeMayNotDeleteOwnSchedule(): void {
+        $this->permissionService->method('canViewEmployee')->willReturn(true);
+        $this->permissionService->method('canManageEmployees')->willReturn(false);
+        $this->workScheduleService->expects($this->never())->method('delete');
+
+        $this->assertSame(403, $this->makeController()->destroy(3, 5)->getStatus());
+    }
+}


### PR DESCRIPTION
Fixes #526

Gemeldet von @jam-ch mit vollstaendiger Reproduktion (beide curl-Aufrufe, gleicher Mitarbeiter, nur unterschiedliche Rolle).

## Ursache

`WorkScheduleController::index()` prueft `canManageEmployees()` — dieselbe Huerde wie `create()`, `update()` und `destroy()` desselben Controllers. Die **eigene** Mitarbeiter-ID kommt in der Pruefung gar nicht vor, deshalb schlaegt `GET api/employees/{id}/schedules` auch fuer die eigenen Daten mit `Access denied` fehl.

In der Weboberflaeche faellt das nie auf: der Arbeitszeitprofil-Editor haengt im Mitarbeiter-Formular, das ohnehin nur Admin/HR erreichen. Ueber die API war es ein harter Blocker fuer jeden Client.

## Fix

Lesen laeuft ueber `canViewEmployee()` — Admin/HR, eigene Daten, Unterstellte. Das ist die Pruefung, die vergleichbare Lese-Endpunkte ohnehin verwenden (`AbsenceController::vacationStats()`; `YearlyCarryoverController::show()` laesst den eigenen Datensatz ebenfalls ausdruecklich durch).

Schreiben bleibt unveraendert bei `canManageEmployees()`.

## Datenschutz

Herausgegeben werden die eigenen Vertragsdaten (Wochenstunden, Urlaubstage, Gueltigkeitszeitraum), die derselbe Mitarbeiter in der Oberflaeche ohnehin angezeigt bekommt. Es wird nichts sichtbar, was vorher verborgen war. Fremde Profile bleiben gesperrt.

## Getestet

**Unit:** neue `WorkScheduleControllerTest`, sechs Faelle ueber drei Rollen — eigenes Profil lesen (der gemeldete Fall), fremdes Profil gesperrt, Vorgesetzter darf Unterstellte lesen, und schreibend (create/update/destroy) bleibt fuer den Mitarbeiter gesperrt, auch am eigenen Profil. Volle Suite 276 gruen.

**Rot-Probe:** mit der alten `canManageEmployees()`-Pruefung fallen genau die beiden Lese-Tests um, die Schreib-Tests bleiben gruen.

**Live gegen lokale Instanz** (NC 34), mit den curl-Aufrufen aus dem Report:

| Aufruf als Mitarbeiter ohne Verwaltungsrecht | vorher | jetzt |
|---|---|---|
| `GET .../employees/1/schedules` (eigene ID) | 403 | **200** + Profil |
| `GET .../employees/99/schedules` (fremd) | 403 | 403 |
| `DELETE .../employees/1/schedules/1` (eigenes Profil) | 403 | 403 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuLo1pVobCsknwFGbHL5rE