### PR TITLE
fix(i18n): Validierungsmeldungen bei Abwesenheiten uebersetzen (#528)

### DIFF
--- a/l10n/cs.js
+++ b/l10n/cs.js
@@ -653,6 +653,11 @@ OC.L10N.register(
     "Profil ruhend – keine Erfassung möglich." : "Profil ruhend – keine Erfassung möglich.",
     "Davon {year} bereits verbraucht" : "Z toho již vyčerpáno v roce {year}",
     "Urlaubstage, die im Eintrittsjahr bereits genommen wurden — beim vorherigen Arbeitgeber oder vor der Umstellung auf diese App. Sie werden nur vom Anspruch des Eintrittsjahres abgezogen. Ab dem Folgejahr gilt wieder der volle Jahresanspruch. Halbe Tage sind möglich." : "Dny dovolené již vyčerpané v roce nástupu — u předchozího zaměstnavatele nebo před přechodem na tuto aplikaci. Odečítají se pouze z nároku roku nástupu. Od následujícího roku opět platí plný roční nárok. Půldny jsou možné.",
-    "Vor Eintritt verbraucht" : "Vyčerpáno před nástupem"
+    "Vor Eintritt verbraucht" : "Vyčerpáno před nástupem",
+    "Nicht genügend Urlaubstage. Verfügbar: %s, beantragt: %s." : "Nedostatek dnů dovolené. K dispozici: %s, požadováno: %s.",
+    "Enddatum muss nach dem Startdatum liegen" : "Datum konce musí být po datu začátku",
+    "Ungültige Option für den Umgang mit fehlendem Resturlaub" : "Neplatná volba pro nedostatek zbývající dovolené",
+    "Ungültige Abwesenheitsart" : "Neplatný typ nepřítomnosti",
+    "Es existiert bereits eine Abwesenheit in diesem Zeitraum" : "V tomto období již existuje nepřítomnost"
 },
 "nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;");

--- a/l10n/cs.json
+++ b/l10n/cs.json
@@ -652,7 +652,12 @@
 		"Profil ruhend – keine Erfassung möglich.": "Profil ruhend – keine Erfassung möglich.",
 		"Davon {year} bereits verbraucht": "Z toho již vyčerpáno v roce {year}",
 		"Urlaubstage, die im Eintrittsjahr bereits genommen wurden — beim vorherigen Arbeitgeber oder vor der Umstellung auf diese App. Sie werden nur vom Anspruch des Eintrittsjahres abgezogen. Ab dem Folgejahr gilt wieder der volle Jahresanspruch. Halbe Tage sind möglich.": "Dny dovolené již vyčerpané v roce nástupu — u předchozího zaměstnavatele nebo před přechodem na tuto aplikaci. Odečítají se pouze z nároku roku nástupu. Od následujícího roku opět platí plný roční nárok. Půldny jsou možné.",
-		"Vor Eintritt verbraucht": "Vyčerpáno před nástupem"
+		"Vor Eintritt verbraucht": "Vyčerpáno před nástupem",
+		"Nicht genügend Urlaubstage. Verfügbar: %s, beantragt: %s.": "Nedostatek dnů dovolené. K dispozici: %s, požadováno: %s.",
+		"Enddatum muss nach dem Startdatum liegen": "Datum konce musí být po datu začátku",
+		"Ungültige Option für den Umgang mit fehlendem Resturlaub": "Neplatná volba pro nedostatek zbývající dovolené",
+		"Ungültige Abwesenheitsart": "Neplatný typ nepřítomnosti",
+		"Es existiert bereits eine Abwesenheit in diesem Zeitraum": "V tomto období již existuje nepřítomnost"
 	},
 	"pluralForm": "nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;"
 }

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -653,6 +653,11 @@ OC.L10N.register(
     "Profil ruhend – keine Erfassung möglich." : "Profil ruhend – keine Erfassung möglich.",
     "Davon {year} bereits verbraucht" : "Davon {year} bereits verbraucht",
     "Urlaubstage, die im Eintrittsjahr bereits genommen wurden — beim vorherigen Arbeitgeber oder vor der Umstellung auf diese App. Sie werden nur vom Anspruch des Eintrittsjahres abgezogen. Ab dem Folgejahr gilt wieder der volle Jahresanspruch. Halbe Tage sind möglich." : "Urlaubstage, die im Eintrittsjahr bereits genommen wurden — beim vorherigen Arbeitgeber oder vor der Umstellung auf diese App. Sie werden nur vom Anspruch des Eintrittsjahres abgezogen. Ab dem Folgejahr gilt wieder der volle Jahresanspruch. Halbe Tage sind möglich.",
-    "Vor Eintritt verbraucht" : "Vor Eintritt verbraucht"
+    "Vor Eintritt verbraucht" : "Vor Eintritt verbraucht",
+    "Nicht genügend Urlaubstage. Verfügbar: %s, beantragt: %s." : "Nicht genügend Urlaubstage. Verfügbar: %s, beantragt: %s.",
+    "Enddatum muss nach dem Startdatum liegen" : "Enddatum muss nach dem Startdatum liegen",
+    "Ungültige Option für den Umgang mit fehlendem Resturlaub" : "Ungültige Option für den Umgang mit fehlendem Resturlaub",
+    "Ungültige Abwesenheitsart" : "Ungültige Abwesenheitsart",
+    "Es existiert bereits eine Abwesenheit in diesem Zeitraum" : "Es existiert bereits eine Abwesenheit in diesem Zeitraum"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -652,7 +652,12 @@
 		"Profil ruhend – keine Erfassung möglich.": "Profil ruhend – keine Erfassung möglich.",
 		"Davon {year} bereits verbraucht": "Davon {year} bereits verbraucht",
 		"Urlaubstage, die im Eintrittsjahr bereits genommen wurden — beim vorherigen Arbeitgeber oder vor der Umstellung auf diese App. Sie werden nur vom Anspruch des Eintrittsjahres abgezogen. Ab dem Folgejahr gilt wieder der volle Jahresanspruch. Halbe Tage sind möglich.": "Urlaubstage, die im Eintrittsjahr bereits genommen wurden — beim vorherigen Arbeitgeber oder vor der Umstellung auf diese App. Sie werden nur vom Anspruch des Eintrittsjahres abgezogen. Ab dem Folgejahr gilt wieder der volle Jahresanspruch. Halbe Tage sind möglich.",
-		"Vor Eintritt verbraucht": "Vor Eintritt verbraucht"
+		"Vor Eintritt verbraucht": "Vor Eintritt verbraucht",
+		"Nicht genügend Urlaubstage. Verfügbar: %s, beantragt: %s.": "Nicht genügend Urlaubstage. Verfügbar: %s, beantragt: %s.",
+		"Enddatum muss nach dem Startdatum liegen": "Enddatum muss nach dem Startdatum liegen",
+		"Ungültige Option für den Umgang mit fehlendem Resturlaub": "Ungültige Option für den Umgang mit fehlendem Resturlaub",
+		"Ungültige Abwesenheitsart": "Ungültige Abwesenheitsart",
+		"Es existiert bereits eine Abwesenheit in diesem Zeitraum": "Es existiert bereits eine Abwesenheit in diesem Zeitraum"
 	},
 	"pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -653,6 +653,11 @@ OC.L10N.register(
     "Profil ruhend – keine Erfassung möglich." : "Profile resting – recording not possible.",
     "Davon {year} bereits verbraucht" : "Of which already used in {year}",
     "Urlaubstage, die im Eintrittsjahr bereits genommen wurden — beim vorherigen Arbeitgeber oder vor der Umstellung auf diese App. Sie werden nur vom Anspruch des Eintrittsjahres abgezogen. Ab dem Folgejahr gilt wieder der volle Jahresanspruch. Halbe Tage sind möglich." : "Vacation days already taken in the year of joining — at a previous employer or before moving to this app. They are deducted from the entitlement of the joining year only. From the following year the full annual entitlement applies again. Half days are possible.",
-    "Vor Eintritt verbraucht" : "Used before joining"
+    "Vor Eintritt verbraucht" : "Used before joining",
+    "Nicht genügend Urlaubstage. Verfügbar: %s, beantragt: %s." : "Not enough vacation days. Available: %s, requested: %s.",
+    "Enddatum muss nach dem Startdatum liegen" : "End date must be after start date",
+    "Ungültige Option für den Umgang mit fehlendem Resturlaub" : "Invalid option for handling insufficient remaining vacation",
+    "Ungültige Abwesenheitsart" : "Invalid absence type",
+    "Es existiert bereits eine Abwesenheit in diesem Zeitraum" : "An absence already exists in this period"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -652,7 +652,12 @@
 		"Profil ruhend – keine Erfassung möglich.": "Profile resting – recording not possible.",
 		"Davon {year} bereits verbraucht": "Of which already used in {year}",
 		"Urlaubstage, die im Eintrittsjahr bereits genommen wurden — beim vorherigen Arbeitgeber oder vor der Umstellung auf diese App. Sie werden nur vom Anspruch des Eintrittsjahres abgezogen. Ab dem Folgejahr gilt wieder der volle Jahresanspruch. Halbe Tage sind möglich.": "Vacation days already taken in the year of joining — at a previous employer or before moving to this app. They are deducted from the entitlement of the joining year only. From the following year the full annual entitlement applies again. Half days are possible.",
-		"Vor Eintritt verbraucht": "Used before joining"
+		"Vor Eintritt verbraucht": "Used before joining",
+		"Nicht genügend Urlaubstage. Verfügbar: %s, beantragt: %s.": "Not enough vacation days. Available: %s, requested: %s.",
+		"Enddatum muss nach dem Startdatum liegen": "End date must be after start date",
+		"Ungültige Option für den Umgang mit fehlendem Resturlaub": "Invalid option for handling insufficient remaining vacation",
+		"Ungültige Abwesenheitsart": "Invalid absence type",
+		"Es existiert bereits eine Abwesenheit in diesem Zeitraum": "An absence already exists in this period"
 	},
 	"pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/lib/Service/AbsenceService.php
+++ b/lib/Service/AbsenceService.php
@@ -276,10 +276,10 @@ class AbsenceService {
         $startDateObj = new DateTime($startDate);
         $endDateObj = new DateTime($endDate);
         if ($startDateObj > $endDateObj) {
-            throw new ValidationException(['endDate' => ['End date must be after start date']]);
+            throw new ValidationException(['endDate' => [$this->l->t('Enddatum muss nach dem Startdatum liegen')]]);
         }
         if (!in_array($overageHandling, self::OVERAGE_OPTIONS, true)) {
-            throw new ValidationException(['overageHandling' => ['Invalid overage handling option']]);
+            throw new ValidationException(['overageHandling' => [$this->l->t('Ungültige Option für den Umgang mit fehlendem Resturlaub')]]);
         }
 
         $employees = [];
@@ -1017,10 +1017,12 @@ class AbsenceService {
             $remaining = $this->remainingVacationDays($employeeId, $year, $federalState, $excludeId);
             if ($requestedInYear > $remaining) {
                 throw new ValidationException([
-                    'vacationQuota' => [sprintf(
-                        'Not enough vacation days. Available: %.1f, requested: %.1f.',
-                        max(0, $remaining),
-                        $requestedInYear
+                    'vacationQuota' => [$this->l->t(
+                        'Nicht genügend Urlaubstage. Verfügbar: %s, beantragt: %s.',
+                        [
+                            number_format(max(0, $remaining), 1, '.', ''),
+                            number_format($requestedInYear, 1, '.', ''),
+                        ]
                     )],
                 ]);
             }
@@ -1100,11 +1102,11 @@ class AbsenceService {
         $errors = [];
 
         if (!array_key_exists($type, Absence::TYPES)) {
-            $errors['type'] = ['Invalid absence type'];
+            $errors['type'] = [$this->l->t('Ungültige Abwesenheitsart')];
         }
 
         if ($startDate > $endDate) {
-            $errors['endDate'] = ['End date must be after start date'];
+            $errors['endDate'] = [$this->l->t('Enddatum muss nach dem Startdatum liegen')];
         }
 
         // Scope must be between 0 and 1
@@ -1128,7 +1130,7 @@ class AbsenceService {
                 || $a->getStatus() === Absence::STATUS_PENDING
         );
         if (!empty($blocking)) {
-            $errors['startDate'] = ['Overlapping absence exists'];
+            $errors['startDate'] = [$this->l->t('Es existiert bereits eine Abwesenheit in diesem Zeitraum')];
         }
 
         return $errors;

--- a/tests/Unit/Service/AbsenceServiceTest.php
+++ b/tests/Unit/Service/AbsenceServiceTest.php
@@ -580,6 +580,69 @@ class AbsenceServiceTest extends TestCase {
     }
 
     // ---------------------------------------------------------------------
+    // #528: Validierungsmeldungen laufen ueber die Uebersetzung
+    // ---------------------------------------------------------------------
+
+    /**
+     * Die Kontingentmeldung wurde frueher per sprintf() hartkodiert und erschien
+     * dadurch auch bei deutscher Oberflaeche auf Englisch. Der Test prueft das
+     * Ergebnis: die Meldung kommt aus dem Uebersetzungskatalog und traegt beide
+     * Zahlen. Der IL10N-Mock in setUp() gibt den Quelltext zurueck und fuellt
+     * die %s-Platzhalter — kommt der Text nicht durch t(), fehlen die Zahlen.
+     */
+    public function testQuotaMessageIsTranslatedAndCarriesBothNumbers(): void {
+        $employee = new Employee();
+        $employee->setId(1);
+        $employee->setFederalState('BW');
+        $employee->setVacationDays(10);
+        $employee->setIsActive(true);
+        $this->employeeMapper->method('find')->willReturn($employee);
+        $this->carryoverService->method('getVacationCarryoverDays')->willReturn(0.0);
+        $this->absenceMapper->method('findByEmployeeAndYear')->willReturn([]);
+        $this->absenceMapper->method('findOverlapping')->willReturn([]);
+        $this->absenceMapper->method('insert')->willReturnArgument(0);
+        $this->timeEntryMapper->method('findByEmployeeAndDateRange')->willReturn([]);
+        $this->timeEntryMapper->method('getMonthlyStatusSummary')->willReturn(
+            ['draft' => 0, 'submitted' => 0, 'approved' => 0, 'rejected' => 0]
+        );
+        $this->holidayMapper->method('findHolidaysInRange')->willReturn([]);
+        $this->workScheduleService->method('countWorkingDays')->willReturn(12.0);
+
+        try {
+            $this->service->create(1, Absence::TYPE_VACATION, '2026-09-01', '2026-09-16', null, 'BW');
+            $this->fail('Expected the quota check to reject the request');
+        } catch (ValidationException $e) {
+            $message = $e->getFieldErrors('vacationQuota')[0];
+            $this->assertStringContainsString('Urlaubstage', $message, 'Meldung kommt nicht aus dem Katalog');
+            $this->assertStringContainsString('10.0', $message, 'Verfuegbare Tage fehlen');
+            $this->assertStringContainsString('12.0', $message, 'Beantragte Tage fehlen');
+            $this->assertStringNotContainsString('%s', $message, 'Platzhalter nicht ersetzt');
+        }
+    }
+
+    /**
+     * Gegenprobe fuer die uebrigen umgestellten Meldungen: ueberlappende
+     * Abwesenheit meldet sich ebenfalls deutsch.
+     */
+    public function testOverlapMessageIsTranslated(): void {
+        $this->expectActiveEmployee();
+        $existing = $this->makeAbsence(
+            Absence::TYPE_VACATION,
+            Absence::STATUS_APPROVED,
+            new DateTime('2026-09-01'),
+            new DateTime('2026-09-03')
+        );
+        $this->absenceMapper->method('findOverlapping')->willReturn([$existing]);
+
+        try {
+            $this->service->create(1, Absence::TYPE_VACATION, '2026-09-02', '2026-09-04');
+            $this->fail('Expected the overlap check to reject the request');
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('Abwesenheit', $e->getFieldErrors('startDate')[0]);
+        }
+    }
+
+    // ---------------------------------------------------------------------
     // #522: im Eintrittsjahr bereits verbrauchte Urlaubstage
     // ---------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #528

## Problem

Beantragt ein Mitarbeiter mehr Urlaub als ihm zusteht, erscheint bei **deutscher** Oberflaeche:

> Not enough vacation days. Available: 20.5, requested: 22.0.

Der Text wird in `checkVacationQuota()` per `sprintf()` hartkodiert und steht in keinem l10n-Katalog. Betroffen waren sechs Meldungen im selben Validierungspfad, die alle als Toast beim Anwender landen:

| Zeile | Text |
|---|---|
| `1021` | `Not enough vacation days. Available: %.1f, requested: %.1f.` |
| `279`, `1107` | `End date must be after start date` |
| `282` | `Invalid overage handling option` |
| `1103` | `Invalid absence type` |
| `1131` | `Overlapping absence exists` |

Direkt daneben liegende Meldungen (`Scope muss zwischen 0 und 1 liegen`) waren korrekt uebersetzt — es war Inkonsistenz, kein bewusster Entwurf. Bestand seit `5e68315` (2026-05-13, #147).

## Warum es so lange unentdeckt blieb

Die Meldungen sind nur beim Durchklicken des Antragsformulars sichtbar. Ueber die API prueft man den Statuscode und den Fehlerschluessel, nicht den Anzeigetext — genau so war es bei der Verifikation von #522 auch, bis ich das Formular tatsaechlich bedient habe.

## Fix

Alle sechs ueber `$this->l->t()`, Zahlen als `%s`-Platzhalter nach dem Muster von `WorkScheduleService::validate()`. Keys in allen sechs l10n-Dateien.

## Getestet

**Unit:** zwei neue Tests, die das **Ergebnis** pruefen statt des Mechanismus — die Meldung muss aus dem Katalog kommen, beide Zahlen tragen und keinen unersetzten Platzhalter enthalten. Volle Suite 272 gruen.

**Rot-Probe:** mit den hartkodierten Texten zurueck fallen beide Tests um (`Failed asserting that 'Not enough vacation days...' contains "Urlaubstage"`).

**Live gegen lokale Instanz**, deutscher Nutzer, echtes Antragsformular:

> Nicht genügend Urlaubstage. Verfügbar: 0.0, beantragt: 21.0.

`l10n-check` ohne Drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuLo1pVobCsknwFGbHL5rE