### PR TITLE
chore(security): .claude/settings.local.json in .gitignore aufnehmen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ npm-debug.log*
 .env
 .env.local
 
+# Claude Code: lokale Secrets (z.B. NC_APPSTORE_TOKEN), siehe .claude/techstack.md
+.claude/settings.local.json
+
 # Composer (vendor/ and composer.lock are committed for deployment)
 
 # Package lock (keep package-lock.json for reproducible builds)


### PR DESCRIPTION
`.claude/settings.local.json` hält lokale Secrets, unter anderem `NC_APPSTORE_TOKEN`.

In diesem Repo griff dafür bisher **keine eigene Regel**. Geschützt war die Datei nur durch die globale Ignore-Datei `~/.config/git/ignore` — die liegt im Home-Verzeichnis der Maschine und wandert nicht mit dem Repo. Auf einem frischen Checkout hätte ein `git add -A` den Token eingecheckt.

## Hintergrund

Aufgefallen bei der Aufarbeitung des App-Store-Token-Leaks in contractmanager: dort stand der Token seit `d89e772` (29.04.2026) hartkodiert in `.claude/techstack.md`, in einem public Repo, gut drei Monate lang. Token am 04.08.2026 rotiert, siehe cpcMomentum/contractmanager#308.

Bei der Nachkontrolle zeigte sich, dass der Schutz für die Ersatz-Ablage selbst nur maschinenlokal war.

## Fleet-Stand

| Repo | vorher |
|---|---|
| contractmanager | nur global — in #308 behoben |
| **worktime** | **nur global — dieser PR** |
| brandmail | nur global — folgt |
| rechnungswerk, vinarium | ignorieren `.claude/` komplett, nicht betroffen |

Zusätzlich ist seit heute GitHubs Secret Scanning inklusive Push Protection in den vier öffentlichen Repos aktiv.

Eine Zeile in `.gitignore`, kein Code.