### PR TITLE
feat(hooks): Secret-Check im Pre-Commit, hooksPath via npm prepare

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -57,7 +57,66 @@ if [ -n "$L10N_RELEVANT" ]; then
     fi
 fi
 
-# --- Check 3: OCP-only API usage in PHP files ---
+# --- Check 3: Secrets in staged files (worktime#538) ---
+# Anlass: der App-Store-Token stand von 04/2026 bis 08/2026 hartkodiert in
+# contractmanager/.claude/techstack.md — in einem oeffentlichen Repo
+# (contractmanager#308). GitHubs Secret Scanning faengt das NICHT: es gibt kein
+# Nextcloud-Muster, und ein blanker 40-Zeichen-Hex-String ist von einem
+# Commit-Hash nicht zu unterscheiden.
+#
+# Deshalb kontextgebunden statt "40 Hex" allein — sonst schlaegt jeder
+# Commit-Hash in CHANGELOG.md oder composer.lock an.
+#
+# Steht bewusst VOR Check 4: der laeuft nur bei PHP-Dateien und beendet den
+# Hook sonst frueh. Der Leak kam ueber eine .md-Datei.
+SECRET_STAGED=$(git diff --cached --name-only --diff-filter=ACM || true)
+if [ -n "$SECRET_STAGED" ]; then
+    SECRET_VIOLATIONS=""
+    for file in $SECRET_STAGED; do
+        [ -f "$file" ] || continue
+        # appinfo/signature.json ist eine generierte Liste aus Dateipfaden und
+        # SHA-512-Hashes. Pfade wie vendor/doctrine/lexer/src/Token.php neben
+        # einem Hash sehen wie ein Geheimnis aus, sind aber keins — und die
+        # Datei wird bei JEDEM Release neu erzeugt.
+        case "$file" in
+            appinfo/signature.json) continue ;;
+        esac
+        CONTENT=$(git show ":$file" 2>/dev/null || true)
+        [ -n "$CONTENT" ] || continue
+
+        # a) App-Store-Token im Authorization-Header (der belegte Fall)
+        # b) langer Hex-Wert auf einer Zeile, die ihn als Geheimnis ausweist
+        # c) private Schluessel (Signaturzertifikate gehoeren nach ~/.nextcloud/)
+        # Treffer zusammenfuehren und je Zeile nur einmal melden — a und b
+        # greifen beim Leak-Fall beide.
+        M=$( {
+            printf '%s' "$CONTENT" | grep -nE 'Authorization:[[:space:]]*Token[[:space:]]+[0-9a-f]{40}' || true
+            printf '%s' "$CONTENT" | grep -niE '(token|secret|api[_-]?key|passwor[dt])["'"'"']?[[:space:]]*[:=]+[[:space:]]*["'"'"']?[0-9a-f]{32,}' || true
+            printf '%s' "$CONTENT" | grep -nE '^-----BEGIN [A-Z ]*PRIVATE KEY-----' || true
+        } | sort -t: -k1,1n -u || true)
+
+        if [ -n "$M" ]; then
+            SECRET_VIOLATIONS="${SECRET_VIOLATIONS}${file}:
+${M}
+
+"
+        fi
+    done
+
+    if [ -n "$SECRET_VIOLATIONS" ]; then
+        printf '\033[0;31m[Secret Check] BLOCKED\033[0m\n\n'
+        printf 'Moeglicher Zugangsschluessel in einer gestagten Datei.\n\n'
+        printf 'Secrets gehoeren nach .claude/settings.local.json (gitignored),\n'
+        printf 'im Code stattdessen die Variable lesen, z.B. $NC_APPSTORE_TOKEN.\n'
+        printf 'Private Schluessel gehoeren nach ~/.nextcloud/certificates/.\n\n'
+        printf '%s' "$SECRET_VIOLATIONS"
+        printf 'Fehlalarm? Dann Muster in .githooks/pre-commit schaerfen —\n'
+        printf 'nicht den Hook mit --no-verify umgehen.\n'
+        exit 1
+    fi
+fi
+
+# --- Check 4: OCP-only API usage in PHP files ---
 PATTERN='(^|[^A-Za-z])OC_[A-Z][a-zA-Z_]*::|\\OC::|\\OC\\[A-Z]|^use OC\\[A-Z]|^use OC;'
 
 STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.php$' || true)

--- a/l10n/README.md
+++ b/l10n/README.md
@@ -45,7 +45,7 @@ Quelltext entsprechen = offene Übersetzungs-Schulden.
 
 ### Durchgesetzt durch
 
-- **Pre-Commit-Hook** (`.githooks/pre-commit`, Check 3) — bei Änderungen an
+- **Pre-Commit-Hook** (`.githooks/pre-commit`, Check 2) — bei Änderungen an
   Code-/Katalog-Dateien.
 - **CI** (`.github/workflows/l10n-check.yml`) — bei Push/PR.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "lint:fix": "eslint --ext .js,.vue src --fix",
         "test": "jest",
         "l10n:check": "node scripts/l10n-check.mjs",
-        "l10n:fix": "node scripts/l10n-check.mjs --fix"
+        "l10n:fix": "node scripts/l10n-check.mjs --fix",
+        "prepare": "git config core.hooksPath .githooks || true"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Fixes #538

## Warum

Der App-Store-Token stand von April bis August 2026 hartkodiert in `contractmanager/.claude/techstack.md`, in einem öffentlichen Repo (cpcMomentum/contractmanager#308). Nichts hat den Commit aufgehalten.

GitHubs Secret Scanning fängt genau diesen Fall **nicht** — kein Nextcloud-Muster, und ein blanker 40-Zeichen-Hex-String ist von einem Commit-Hash nicht zu unterscheiden. Push Protection ist seit 04.08.2026 trotzdem aktiv, sie deckt andere Secret-Typen ab.

Randnotiz: GitGuardian hat den Token am 04.08. abends gemeldet — ausgelöst durch unseren eigenen Aufräum-Commit, in dessen Diff der Wert als entfernte Zeile steht. Externe Erkennung existiert also, aber reaktiv und nur für öffentliche Repos.

## Was drin ist

**1. Secret-Check als Check 3 in `.githooks/pre-commit`**, kontextgebunden statt „40 Hex" allein:

| Muster | fängt |
|---|---|
| `Authorization: Token <40 hex>` | den belegten Fall |
| `token`/`secret`/`api_key`/`password` als Zuweisung mit Hex-Wert | Konfigurationsdateien |
| `-----BEGIN ... PRIVATE KEY-----` | Signaturzertifikate |

Er steht **vor** dem OCP-Check. Der läuft nur bei PHP-Dateien und beendet den Hook sonst früh — der Leak kam über eine `.md`-Datei und wäre dahinter nie gesehen worden.

`appinfo/signature.json` ist ausgenommen: die generierte Hash-Liste enthält Pfade wie `vendor/doctrine/lexer/src/Token.php` neben einem SHA-512 und hätte sonst **jedes Release blockiert**. Das war der einzige Fehlalarm im Test und der Grund für die Verschärfung auf Zuweisungs-Kontext.

**2. `"prepare": "git config core.hooksPath .githooks"` in `package.json`.** Die Hooks lagen im Repo, aber git aktiviert sie nicht von selbst — in contractmanager war die Konfiguration nie gesetzt, **die Hooks liefen dort nie**. Ab jetzt erledigt `npm install` das.

## Getestet

| Fall | erwartet | Ergebnis |
|---|---|---|
| `Authorization: Token <hex>` | blockiert | blockiert |
| Token als JSON-Zuweisung | blockiert | blockiert |
| `API_SECRET = "<hex>"` | blockiert | blockiert |
| privater Schlüssel | blockiert | blockiert |
| Commit-Hashes im Fließtext | durchlassen | durchgelassen |
| Wort `token` im Code | durchlassen | durchgelassen |

**Fehlalarme: 0** über alle 942 getrackten Dateien in worktime, contractmanager, rechnungswerk, vinarium und brandmail.

**Der echte Commit vom 29.04.2026 wäre blockiert worden** — gegen den historischen Dateiinhalt aus `d89e772` verifiziert.

Der Hook enthält seine eigenen Muster als Text und lässt sich selbst durch, wie dieser Commit zeigt.

## Danach

Nach dem Merge 1:1 in contractmanager, rechnungswerk, vinarium und brandmail. Bei contractmanager zusätzlich der Hook-Drift: dort fehlen Konfliktmarker- und l10n-Check (44 statt 89 Zeilen), der l10n-Teil nur, wo `scripts/l10n-check.mjs` existiert.