### PR TITLE
feat(projects): nach Projektcode sortieren, Klammern im Anzeigenamen weglassen

### DIFF
--- a/lib/Db/Project.php
+++ b/lib/Db/Project.php
@@ -74,9 +74,15 @@ class Project extends Entity implements JsonSerializable {
         $this->markFieldUpdated('allEmployees');
     }
 
+    /**
+     * Anzeigename fuer Auswahlfelder: Code vorangestellt, ohne Klammern (#550).
+     *
+     * Die Listen sind nach Code sortiert, deshalb steht er vorn — die eckigen
+     * Klammern trugen dabei nichts bei und machten die Zeile nur unruhiger.
+     */
     public function getDisplayName(): string {
         if ($this->code) {
-            return "[{$this->code}] {$this->name}";
+            return "{$this->code} {$this->name}";
         }
         return $this->name;
     }

--- a/lib/Db/ProjectMapper.php
+++ b/lib/Db/ProjectMapper.php
@@ -25,6 +25,57 @@ class ProjectMapper extends QBMapper {
     }
 
     /**
+     * Projekte nach Projektcode ordnen (#550).
+     *
+     * Vorher lief alles nach Name, wodurch die Codes in den Auswahlfeldern
+     * zufaellig verstreut wirkten — sie waren gar nicht der Sortierschluessel.
+     *
+     * Die Regel ist bewusst dreiteilig, weil die Codes gemischt sind:
+     * rein numerische Codes werden numerisch verglichen (sonst stuende 1024
+     * vor 98), alphanumerische kommen dahinter, und Projekte ohne Code ganz
+     * zuletzt. Damit bleibt auch die Konvention wirksam, interne Toepfe ueber
+     * Codes wie ZZX/ZZY/ZZZ ans Ende zu schieben.
+     *
+     * Warum in PHP und nicht per ORDER BY: die Zeichenkettensortierung der
+     * Datenbank haette dasselbe Laengenproblem, und `code` ist nullable — die
+     * Einordnung von NULL unterscheidet sich zwischen PostgreSQL (hinten),
+     * MySQL und SQLite (vorn). Bei dieser Datenmenge ist das unkritisch und
+     * ueber alle unterstuetzten Datenbanken gleich.
+     *
+     * @param Project[] $projects
+     * @return Project[]
+     */
+    public static function sortByCode(array $projects): array {
+        usort($projects, static function (Project $a, Project $b): int {
+            $codeA = trim((string)$a->getCode());
+            $codeB = trim((string)$b->getCode());
+
+            if ($codeA === '' || $codeB === '') {
+                // Ohne Code nach hinten; sind beide ohne, entscheidet der Name.
+                if ($codeA === $codeB) {
+                    return strcasecmp($a->getName(), $b->getName());
+                }
+                return $codeA === '' ? 1 : -1;
+            }
+
+            $numericA = ctype_digit($codeA);
+            $numericB = ctype_digit($codeB);
+
+            if ($numericA && $numericB) {
+                $cmp = (int)$codeA <=> (int)$codeB;
+            } elseif ($numericA !== $numericB) {
+                $cmp = $numericA ? -1 : 1;
+            } else {
+                $cmp = strcasecmp($codeA, $codeB);
+            }
+
+            return $cmp !== 0 ? $cmp : strcasecmp($a->getName(), $b->getName());
+        });
+
+        return $projects;
+    }
+
+    /**
      * @throws DoesNotExistException
      * @throws MultipleObjectsReturnedException
      */
@@ -46,7 +97,9 @@ class ProjectMapper extends QBMapper {
             ->from($this->getTableName())
             ->orderBy('name', 'ASC');
 
-        return $this->findEntities($qb);
+        // name als stabile Grundordnung; die eigentliche Reihenfolge macht
+        // sortByCode() (#550).
+        return self::sortByCode($this->findEntities($qb));
     }
 
     /**
@@ -59,7 +112,9 @@ class ProjectMapper extends QBMapper {
             ->where($qb->expr()->eq('is_active', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)))
             ->orderBy('name', 'ASC');
 
-        return $this->findEntities($qb);
+        // name als stabile Grundordnung; die eigentliche Reihenfolge macht
+        // sortByCode() (#550).
+        return self::sortByCode($this->findEntities($qb));
     }
 
     /**
@@ -86,7 +141,9 @@ class ProjectMapper extends QBMapper {
             ->andWhere($qb->expr()->eq('is_billable', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)))
             ->orderBy('name', 'ASC');
 
-        return $this->findEntities($qb);
+        // name als stabile Grundordnung; die eigentliche Reihenfolge macht
+        // sortByCode() (#550).
+        return self::sortByCode($this->findEntities($qb));
     }
 
     public function existsByCode(string $code, ?int $excludeId = null): bool {

--- a/tests/Unit/Db/ProjectMapperSortTest.php
+++ b/tests/Unit/Db/ProjectMapperSortTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Tests\Unit\Db;
+
+use OCA\WorkTime\Db\Project;
+use OCA\WorkTime\Db\ProjectMapper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Sortierung der Projektlisten nach Projektcode (#550).
+ *
+ * Vorher lief alles nach Name, wodurch die Codes in den Auswahlfeldern
+ * zufaellig verstreut wirkten. Die Faelle hier sind genau die, an denen eine
+ * naive Loesung scheitert.
+ */
+class ProjectMapperSortTest extends TestCase {
+
+    private function project(?string $code, string $name): Project {
+        $project = new Project();
+        $project->setCode($code);
+        $project->setName($name);
+
+        return $project;
+    }
+
+    /**
+     * @param array<array{0: ?string, 1: string}> $input
+     * @return string[] Codes in sortierter Reihenfolge, '-' fuer ohne Code
+     */
+    private function sortedCodes(array $input): array {
+        $projects = array_map(fn (array $p): Project => $this->project($p[0], $p[1]), $input);
+
+        return array_map(
+            static fn (Project $p): string => $p->getCode() ?? '-',
+            ProjectMapper::sortByCode($projects),
+        );
+    }
+
+    public function testRealWorldOrderFromTheIssue(): void {
+        // Die Liste aus dem Screenshot, vorher nach Name sortiert.
+        $sorted = $this->sortedCodes([
+            ['ZZX', 'Akquise'],
+            ['514', 'EUDI-Wallet'],
+            ['512', 'Fraktionsbüro'],
+            ['498', 'HSH'],
+            ['ZZZ', 'Interne IT'],
+            ['501', 'Politpilot'],
+            ['517', 'Valore'],
+            ['ZZY', 'Verwaltung und Orga'],
+        ]);
+
+        $this->assertSame(
+            ['498', '501', '512', '514', '517', 'ZZX', 'ZZY', 'ZZZ'],
+            $sorted,
+        );
+    }
+
+    public function testNumericCodesAreComparedNumerically(): void {
+        // Reine Zeichenkettensortierung ergaebe 1024, 498, 98 — falsch.
+        $sorted = $this->sortedCodes([
+            ['1024', 'Tausend'],
+            ['98', 'Achtundneunzig'],
+            ['498', 'Vierhundert'],
+        ]);
+
+        $this->assertSame(['98', '498', '1024'], $sorted);
+    }
+
+    public function testNumericCodesComeBeforeAlphanumericOnes(): void {
+        // Traegt die Konvention, interne Toepfe ueber ZZ-Codes ans Ende zu legen.
+        $sorted = $this->sortedCodes([
+            ['ZZX', 'Akquise'],
+            ['1024', 'Projekt'],
+            ['A1', 'Sonderfall'],
+        ]);
+
+        $this->assertSame(['1024', 'A1', 'ZZX'], $sorted);
+    }
+
+    public function testProjectsWithoutCodeGoLast(): void {
+        // Leerer String und null zaehlen beide als "kein Code"; untereinander
+        // entscheidet der Name (Leerer Code vor Ohne Code).
+        $projects = ProjectMapper::sortByCode([
+            $this->project(null, 'Ohne Code'),
+            $this->project('ZZZ', 'Interne IT'),
+            $this->project('', 'Leerer Code'),
+            $this->project('501', 'Politpilot'),
+        ]);
+
+        $this->assertSame(
+            ['Politpilot', 'Interne IT', 'Leerer Code', 'Ohne Code'],
+            array_map(static fn (Project $p): string => $p->getName(), $projects),
+        );
+    }
+
+    public function testProjectsWithoutCodeAreOrderedByName(): void {
+        $projects = ProjectMapper::sortByCode([
+            $this->project(null, 'Zebra'),
+            $this->project(null, 'Anton'),
+        ]);
+
+        $this->assertSame(
+            ['Anton', 'Zebra'],
+            array_map(static fn (Project $p): string => $p->getName(), $projects),
+        );
+    }
+
+    public function testEqualCodesFallBackToName(): void {
+        // Codes sind nicht eindeutigkeitspflichtig, die Reihenfolge muss
+        // trotzdem stabil sein.
+        $projects = ProjectMapper::sortByCode([
+            $this->project('500', 'Zweitprojekt'),
+            $this->project('500', 'Erstprojekt'),
+        ]);
+
+        $this->assertSame(
+            ['Erstprojekt', 'Zweitprojekt'],
+            array_map(static fn (Project $p): string => $p->getName(), $projects),
+        );
+    }
+
+    public function testAlphanumericCodesIgnoreCase(): void {
+        $sorted = $this->sortedCodes([
+            ['zzb', 'Klein'],
+            ['ZZA', 'Gross'],
+        ]);
+
+        $this->assertSame(['ZZA', 'zzb'], $sorted);
+    }
+
+    public function testSurroundingWhitespaceDoesNotBreakOrder(): void {
+        $sorted = $this->sortedCodes([
+            [' 512 ', 'Mit Leerzeichen'],
+            ['498', 'Ohne'],
+        ]);
+
+        $this->assertSame(['498', ' 512 '], $sorted);
+    }
+
+    public function testEmptyListStaysEmpty(): void {
+        $this->assertSame([], ProjectMapper::sortByCode([]));
+    }
+}


### PR DESCRIPTION
Fixes #550

## Was war

Die Projektnummern im Auswahlfeld wirkten zufällig verstreut. Grund: alle drei Listen-Abfragen im `ProjectMapper` sortierten nach `name`, der Code lief nur mit. Dazu die eckigen Klammern um den Code.

## Was jetzt ist

Sortiert wird nach Code, und der Anzeigename kommt ohne Klammern:

```
498 HSH
501 Politpilot
512 Fraktionsbüro
514 EUDI-Wallet
517 Valore
1024 Langnummer-Test
ZZX Akquise
ZZY Verwaltung und Orga
ZZZ Interne IT
Ganz ohne Code
```

## Die Sortierregel

Dreiteilig, weil die Codes gemischt sind:

1. **Rein numerische Codes numerisch** — eine Zeichenkettensortierung stellte `1024` vor `98`
2. **Alphanumerische dahinter** — damit trägt die Konvention, interne Töpfe über Codes wie `ZZX`/`ZZY`/`ZZZ` ans Ende zu legen
3. **Ohne Code ganz zuletzt**, untereinander nach Name

**Warum in PHP und nicht per `ORDER BY`:** Die Zeichenkettensortierung der Datenbank hätte dasselbe Längenproblem, und `code` ist nullable — die Einordnung von NULL unterscheidet sich zwischen PostgreSQL (hinten), MySQL und SQLite (vorn). `sortByCode()` ist statisch und dadurch ohne Datenbank testbar; die drei Abfragen teilen sie, damit die Reihenfolge nicht auseinanderläuft.

## Reichweite

`getDisplayName()` wird nur in `jsonSerialize()` verwendet und im Frontend nur als Label des Auswahlfelds. Berichte, CSV und PDF nutzen `getName()` — dort ändert sich nichts. Die Klammern wurden nirgends geparst.

Die **Einstellungs-Tabelle** übernimmt die Reihenfolge aus dem Store und damit direkt aus dem Mapper. Sie brauchte keine eigene Änderung und ist trotzdem mit sortiert.

## Bewusst nicht geändert

Die **Filter-Chips in der Auswertung** sortieren weiter nach Name. Das Issue schlug vor, sie mitzuziehen — dagegen spricht, dass der Code dort gar nicht angezeigt wird. Nach einem unsichtbaren Schlüssel zu sortieren erzeugt genau den Eindruck von Unordnung, um den es hier geht. Abgestimmt.

## Getestet

- **320 PHPUnit-Tests grün**, davon 9 neue für die Sortierregel: die Liste aus dem Issue, unterschiedlich lange Nummern, numerisch vor alphanumerisch, ohne Code zuletzt, gleiche Codes mit Namens-Tiebreak, Groß-/Kleinschreibung, umgebende Leerzeichen, leere Liste
- **Auf der laufenden Instanz** mit genau den Codes aus dem Issue angelegt und an drei Stellen gegengeprüft — API, Einstellungs-Tabelle und Auswahlfeld liefern übereinstimmend dieselbe Reihenfolge
- Reine Backend-Änderung: kein Bundle betroffen, keine neuen übersetzbaren Texte

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpB46dEsxmXsSUMGLR6T11
