### PR TITLE
chore(l10n): nc-app-tooling auf v1.3.0 angleichen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "babel-jest": "^29.7.0",
                 "eslint": "^8.57.0",
                 "jest": "^29.7.0",
-                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.1.0",
+                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.3.0",
                 "vue-loader": "^17.4.2",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^6.0.1"
@@ -13261,8 +13261,8 @@
             "license": "MIT"
         },
         "node_modules/nc-app-tooling": {
-            "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#168f42acb1ff4b384b3ba851358a94fa78d69a91",
+            "version": "1.3.0",
+            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#14fefd522e6fbb235861aa86943ffe2c055d8007",
             "dev": true,
             "license": "AGPL-3.0-or-later",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "babel-jest": "^29.7.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
-        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.1.0",
+        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.3.0",
         "vue-loader": "^17.4.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^6.0.1"


### PR DESCRIPTION
Angleichung aus contractmanager#339. Dieses Repo stand auf `v1.1.0`, die Flotte lief auf drei verschiedenen Staenden.

Alle Korrekturen sind beim Ausrollen auf die uebrigen Apps entstanden, greifen aber ueberall:

- **Sprachvergleich** (`v1.2.0`): `de.json` und `en.json` konnten unterschiedliche Schluesselsaetze tragen, ohne dass der Pruefer anschlug. Die Pruefungen liefen je Sprache und konnten das nicht sehen. In vinarium lagen so drei veraltete Pluralschluessel nur noch in `de`.
- **Zusammengesetzte PHP-Meldungen** (`v1.3.0`): Der Regex las bei `->t('Erster Teil. ' . 'Zweiter Teil.')` nur das erste Literal und trug ein Fragment ein, das nie nachgeschlagen wird. In projektwerk blieb dadurch ein Setup-Check unuebersetzt, waehrend die Pruefung gruen meldete.

**Kein Befund in diesem Repo.** Mit `v1.3.0` laufen die Kataloge unveraendert sauber durch — der Bump ist Vorsorge, kein Fix. Nur `package.json` und `package-lock.json` geaendert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)