### PR TITLE
ci: vergessene Frontend-Builds fangen (nc-bundle-check)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Volle Historie: der Bundle-Check diffst gegen den Ziel-Branch
+          # und braucht die Merge-Base.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -31,6 +35,17 @@ jobs:
 
       - name: Abhaengigkeiten installieren
         run: npm ci
+
+      # Faengt vergessene Frontend-Builds. Kein Byte-Diff — der Build ist in der
+      # CI nicht reproduzierbar (contractmanager#251): der Lock wird verworfen
+      # und die Node-Version weicht ab, ein Rebuild ohne Quelltextaenderung
+      # erzeugt schon andere Minifier-Kuerzel. Stattdessen: wurden Eingaben
+      # geaendert, ohne dass sich js/ und css/ geaendert haben? Genau so blieb
+      # bei contractmanager#327 eine verwundbare Abhaengigkeit im
+      # ausgelieferten Bundle stehen.
+      - name: Bundle aktuell
+        if: github.event_name == 'pull_request'
+        run: npx --no-install nc-bundle-check "origin/${{ github.base_ref }}"
 
       - name: ESLint
         run: npm run lint

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -45,7 +45,11 @@ jobs:
       # ausgelieferten Bundle stehen.
       - name: Bundle aktuell
         if: github.event_name == 'pull_request'
-        run: npx --no-install nc-bundle-check "origin/${{ github.base_ref }}"
+        env:
+          # Nicht direkt in run: interpolieren — ein Branch-Name kann
+          # Shell-Metazeichen enthalten (Script-Injection).
+          BASE_REF: ${{ github.base_ref }}
+        run: npx --no-install nc-bundle-check "origin/$BASE_REF"
 
       - name: ESLint
         run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "babel-jest": "^29.7.0",
                 "eslint": "^8.57.0",
                 "jest": "^29.7.0",
-                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.4.0",
+                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.9.0",
                 "vue-loader": "^17.4.2",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^6.0.1"
@@ -13261,13 +13261,15 @@
             "license": "MIT"
         },
         "node_modules/nc-app-tooling": {
-            "version": "1.4.0",
-            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#543e32ff674045f1f928f547587aacebd1202286",
+            "version": "1.9.0",
+            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#8319d1c62d405a8ad4ce887d247d6d9d1da06c9f",
             "dev": true,
             "license": "AGPL-3.0-or-later",
             "bin": {
+                "nc-bundle-check": "bin/bundle-check.mjs",
                 "nc-l10n-check": "bin/l10n-check.mjs",
-                "nc-pre-commit": "bin/pre-commit.mjs"
+                "nc-pre-commit": "bin/pre-commit.mjs",
+                "nc-release-check": "bin/release-check.mjs"
             },
             "engines": {
                 "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "babel-jest": "^29.7.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
-        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.4.0",
+        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.9.0",
         "vue-loader": "^17.4.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^6.0.1"


### PR DESCRIPTION
Uebernimmt den Bundle-Check aus contractmanager#351, wo er #251 geschlossen hat.

## Was er fangen soll

Die Apps liefern ihr kompiliertes `js/` und `css/` mit aus. Wer die Quellen aendert und den Build vergisst, deployt alten Code — und keine Testsuite faellt darueber, weil alle gegen die Quellen laufen. Bei contractmanager#327 blieb so eine verwundbare dompurify-Version im ausgelieferten Bundle stehen.

## Warum kein Byte-Diff

Der naheliegende Weg (`npm run build && git diff --exit-code js/ css/`) funktioniert nicht: die CI wirft den Lock weg (npm/cli#4828) und baut mit anderer Node-Version als der committete Stand. Gemessen: ein Rebuild ohne jede Quelltextaenderung erzeugt schon andere Minifier-Kuerzel.

Die Pruefung vergleicht deshalb keine Bytes, sondern fragt: **wurden Eingaben geaendert, ohne dass sich die Ausgaben geaendert haben?**

## Gegen Fehlalarme gehaertet

Beide Verfeinerungen entstanden, weil die erste Fassung an echter Historie falsch anschlug:

- `package.json` zaehlt nicht als Eingabe — dort aendern sich meist nur npm-Skripte.
- Aendert nur das Lockfile, wird geprueft, ob ueberhaupt eine Laufzeit-Abhaengigkeit betroffen ist. Reine Entwicklungspakete markiert das Lockfile selbst mit `dev: true`. Ohne das wuerde jeder Dependabot-Bump auf eslint oder vite anschlagen — und ein Check, der staendig falsch anschlaegt, wird abgeschaltet.

An contractmanagers Historie belegt: der echte dompurify-Bump wird abgewiesen, drei Fehlalarm-Kandidaten laufen durch.

## Ausweg

Beruehrt eine Aenderung das Bundle nachweislich nicht: `[skip bundle-check]` in die Commit-Nachricht — sichtbar im Verlauf statt als stiller Schalter.

## Nebenbei

`actions/checkout` braucht hier jetzt `fetch-depth: 0`, sonst fehlt die Merge-Base fuer den Diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
