### PR TITLE
ci: Bundle-Check nicht mehr blockierend (nc-app-tooling#4)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -43,8 +43,13 @@ jobs:
       # geaendert, ohne dass sich js/ und css/ geaendert haben? Genau so blieb
       # bei contractmanager#327 eine verwundbare Abhaengigkeit im
       # ausgelieferten Bundle stehen.
-      - name: Bundle aktuell
+      # Nicht blockierend, bis nc-app-tooling#1 steht: der Check raet, statt zu
+      # messen — „Quelle geaendert, Bundle unveraendert" ist bei reinen Typ- und
+      # Kommentaraenderungen ein korrekter Zustand. Das Signal bleibt sichtbar,
+      # haelt aber niemanden auf.
+      - name: Bundle aktuell (Hinweis, siehe nc-app-tooling#1)
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         env:
           # Nicht direkt in run: interpolieren — ein Branch-Name kann
           # Shell-Metazeichen enthalten (Script-Injection).


### PR DESCRIPTION
Setzt `continue-on-error: true` am Schritt „Bundle aktuell".

Der Check schliesst aus „Quelle geaendert + Bundle unveraendert" auf einen vergessenen Build. In einer Vue-3-Codebasis ist das aber ein haeufiger **korrekter** Zustand: Typangaben, Interfaces und Kommentare verschwinden beim Kompilieren. Belegt an projektwerk `b50e137` — geaendert waren eine JSDoc-Zeile und eine Typangabe, `npm run build` erzeugte keine Aenderung, der PR wurde trotzdem blockiert.

Der Ausweg `[skip bundle-check]` verlangt, dass jemand die Ursache kennt und einen Marker in eine Commit-Nachricht schreibt. Das ist zu viel Wissen fuer einen Fehlalarm.

Das Signal bleibt sichtbar, haelt aber niemanden auf. Der Schrittname nennt den Grund, damit niemand raetseln muss, warum ein roter Schritt nicht blockiert.

Zurueckgenommen wird die Massnahme mit cpcMomentum/nc-app-tooling#1, sobald der Check misst statt zu raten.

Teil von cpcMomentum/nc-app-tooling#4 (flottenweit, fuenf identische PRs).