### PR TITLE
chore(deps): nc-app-tooling auf v1.10.0 (nc-bundle-fresh)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "babel-jest": "^29.7.0",
                 "eslint": "^8.57.0",
                 "jest": "^29.7.0",
-                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.9.0",
+                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.10.0",
                 "vue-loader": "^17.4.2",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^6.0.1"
@@ -13261,12 +13261,13 @@
             "license": "MIT"
         },
         "node_modules/nc-app-tooling": {
-            "version": "1.9.0",
-            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#8319d1c62d405a8ad4ce887d247d6d9d1da06c9f",
+            "version": "1.10.0",
+            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#a02d303cc01b2e24464c3cca87dacec04aea58ef",
             "dev": true,
             "license": "AGPL-3.0-or-later",
             "bin": {
                 "nc-bundle-check": "bin/bundle-check.mjs",
+                "nc-bundle-fresh": "bin/bundle-fresh.mjs",
                 "nc-l10n-check": "bin/l10n-check.mjs",
                 "nc-pre-commit": "bin/pre-commit.mjs",
                 "nc-release-check": "bin/release-check.mjs"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "babel-jest": "^29.7.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
-        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.9.0",
+        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.10.0",
         "vue-loader": "^17.4.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^6.0.1"


### PR DESCRIPTION
Zieht `nc-app-tooling` von `v1.9.0` auf `v1.10.0` nach.

Neu darin ist `nc-bundle-fresh` (cpcMomentum/nc-app-tooling#2): es baut aus dem exakten HEAD-Stand neu und hält das Ergebnis per SHA-256 gegen das `js/` und `css/` im Arbeitsbaum. Der Release-Skill ruft es in Schritt 4.8 als `npx --no-install nc-bundle-fresh` auf — ohne diesen Bump greift der Schritt in dieser App nicht.

Bis dahin bestand ein veraltetes, aber vorhandenes Bundle jede der 15 Tarball-Prüfungen: keine davon vergleicht Bundle gegen `src/`.

Dazu im Werkzeug-Repo: die ersten Tests und eine eigene CI gegen Node 20 und 24.

Geprüft: `npx --no-install nc-bundle-fresh` läuft in dieser App und meldet grün.