### PR TITLE
ci: Bundle-Frische messen statt raten (nc-app-tooling#1)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -23,38 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Volle Historie: der Bundle-Check diffst gegen den Ziel-Branch
-          # und braucht die Merge-Base.
-          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Abhaengigkeiten installieren
         run: npm ci
-
-      # Faengt vergessene Frontend-Builds. Kein Byte-Diff — der Build ist in der
-      # CI nicht reproduzierbar (contractmanager#251): der Lock wird verworfen
-      # und die Node-Version weicht ab, ein Rebuild ohne Quelltextaenderung
-      # erzeugt schon andere Minifier-Kuerzel. Stattdessen: wurden Eingaben
-      # geaendert, ohne dass sich js/ und css/ geaendert haben? Genau so blieb
-      # bei contractmanager#327 eine verwundbare Abhaengigkeit im
-      # ausgelieferten Bundle stehen.
-      # Nicht blockierend, bis nc-app-tooling#1 steht: der Check raet, statt zu
-      # messen — „Quelle geaendert, Bundle unveraendert" ist bei reinen Typ- und
-      # Kommentaraenderungen ein korrekter Zustand. Das Signal bleibt sichtbar,
-      # haelt aber niemanden auf.
-      - name: Bundle aktuell (Hinweis, siehe nc-app-tooling#1)
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        env:
-          # Nicht direkt in run: interpolieren — ein Branch-Name kann
-          # Shell-Metazeichen enthalten (Script-Injection).
-          BASE_REF: ${{ github.base_ref }}
-        run: npx --no-install nc-bundle-check "origin/$BASE_REF"
 
       - name: ESLint
         run: npm run lint
@@ -64,3 +40,24 @@ jobs:
 
       - name: Produktions-Build
         run: npm run build
+
+      # Der eigentliche Frische-Test: passt das eingecheckte Bundle zu den
+      # Quellen? Der Schritt darueber hat gerade neu gebaut -- weicht js/ oder
+      # css/ jetzt vom Commit ab, wurde beim Aendern der Quellen der Build
+      # vergessen. Genau so blieb bei contractmanager#327 eine verwundbare
+      # dompurify-Version im ausgelieferten Bundle stehen.
+      #
+      # Gemessen statt geraten. Der Vorgaenger (nc-bundle-check) schloss aus
+      # "src/ geaendert, js/ nicht" auf eine Absicht und lag bei reinen Typ- und
+      # Kommentaraenderungen falsch; sein Ausweg [skip bundle-check] hebelte ihn
+      # ganz aus. Beides faellt hiermit weg (nc-app-tooling#1).
+      #
+      # Traegt, weil der Build byte-reproduzierbar ist: alle fuenf Apps bauen
+      # unter Linux mit npm 11 aus dem auf macOS erzeugten Lockfile
+      # byte-identisch (nachgemessen 15.08.2026, Node 20/22/24 einzeln).
+      - name: Bundle passt zum Quellstand
+        run: |
+          if ! git diff --exit-code -- js/ css/; then
+            echo "::error::Das eingecheckte Bundle passt nicht zu den Quellen. Bitte 'npm run build' laufen lassen und das Ergebnis mitcommitten."
+            exit 1
+          fi

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -56,11 +56,19 @@ jobs:
       # unter Linux mit npm 11 aus dem auf macOS erzeugten Lockfile
       # byte-identisch (nachgemessen 15.08.2026, Node 20/22/24 einzeln).
       #
-      # git status statt git diff: der Diff sieht nur getrackte Dateien. Bei
-      # worktime und rechnungswerk tragen die Chunks Content-Hashes im Namen --
-      # ein neu entstandener Chunk kaeme als UNTRACKED daher und rutschte
-      # durch, waehrend die alte Datei unveraendert daneben liegen bleibt.
-      # status --porcelain erfasst geaendert, geloescht und neu.
+      # git status statt git diff: der Diff sieht nur getrackte Dateien. Die
+      # Chunks hier tragen Content-Hashes im Namen -- ein neu entstandener
+      # Chunk kaeme als UNTRACKED daher und rutschte durch, waehrend die alte
+      # Datei unveraendert daneben liegen bleibt. status --porcelain erfasst
+      # geaendert, geloescht und neu.
+      #
+      # Zum css/ im Pfad: worktime erzeugt gar keines. Der webpack-Build
+      # injiziert die Styles per style-loader IN das JS-Bundle (nachgesehen
+      # 15.08.2026: nach `npm run build` existiert kein css/-Verzeichnis).
+      # Die Styles sind damit ueber js/ mitgeprueft. Der Pfad bleibt trotzdem
+      # stehen, damit der Schritt in allen fuenf Apps gleich lautet -- und
+      # falls hier je ein CSS-Bundle entsteht, muesste `css/*.css` aus der
+      # .gitignore, sonst waere es weder getrackt noch geprueft.
       - name: Bundle passt zum Quellstand
         run: |
           ABWEICHUNG=$(git status --porcelain -- js/ css/)

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -55,9 +55,17 @@ jobs:
       # Traegt, weil der Build byte-reproduzierbar ist: alle fuenf Apps bauen
       # unter Linux mit npm 11 aus dem auf macOS erzeugten Lockfile
       # byte-identisch (nachgemessen 15.08.2026, Node 20/22/24 einzeln).
+      #
+      # git status statt git diff: der Diff sieht nur getrackte Dateien. Bei
+      # worktime und rechnungswerk tragen die Chunks Content-Hashes im Namen --
+      # ein neu entstandener Chunk kaeme als UNTRACKED daher und rutschte
+      # durch, waehrend die alte Datei unveraendert daneben liegen bleibt.
+      # status --porcelain erfasst geaendert, geloescht und neu.
       - name: Bundle passt zum Quellstand
         run: |
-          if ! git diff --exit-code -- js/ css/; then
+          ABWEICHUNG=$(git status --porcelain -- js/ css/)
+          if [ -n "$ABWEICHUNG" ]; then
+            echo "$ABWEICHUNG"
             echo "::error::Das eingecheckte Bundle passt nicht zu den Quellen. Bitte 'npm run build' laufen lassen und das Ergebnis mitcommitten."
             exit 1
           fi


### PR DESCRIPTION
Ersetzt den ratenden `nc-bundle-check` durch einen echten Vergleich, hebt die CI auf Node 24 und installiert wieder aus dem Lockfile.

Fixes cpcMomentum/nc-app-tooling#1 (Teil der flottenweiten Umsetzung)

## Warum das jetzt geht

Der alte Check schloss aus „`src/` geändert + `js/` nicht" auf einen vergessenen Build. Das ist bei reinen Typ- und Kommentaränderungen ein **korrekter** Zustand — deshalb stand er seit gestern auf `continue-on-error`. Umgekehrt galt *jede* Änderung unter `js/` als „mitgebaut", ein Bundle aus einem fremden Stand bestand die Prüfung.

Der Byte-Diff galt als unmöglich, weil die CI das Lockfile wegwarf (`rm -f package-lock.json`, Verweis auf npm/cli#4828) und damit floatende Versionen installierte. **Diese Begründung hält nicht.** Im Container nachgestellt (15.08.2026):

- Der Fehler, der bei `npm ci` tatsächlich auftrat, war nicht das fehlende rollup-Binary, sondern ein Auflösungsfehler von npm 10: `Missing: pinia@3.0.4` auf einem Lockfile, das synchron ist (`pinia` steht als `^2.3.1` drin, und `3.0.4` erfüllt das gar nicht).
- Mit npm 11 — das mit Node 24 kommt — läuft `npm ci` durch.
- Danach bauen **alle fünf Apps unter Linux byte-identisch** zum eingecheckten Bundle, aus einem auf macOS erzeugten Lockfile. Für contractmanager unter Node 20, 22 und 24 einzeln geprüft.

## Was sich ändert

| | vorher | nachher |
|---|---|---|
| Node | 20 (EOL seit 30.04.2026) | 24 |
| Installation | Lockfile weg, `npm install` | `npm ci` |
| Frische-Prüfung | Heuristik, nicht blockierend | `git diff --exit-code -- js/ css/` nach dem Build |
| `[skip bundle-check]` | hebelte alles aus | entfällt mit seinem Grund |
| `fetch-depth: 0` | für die Merge-Base des alten Checks | entfällt, der Vergleich braucht keine Historie |

Kostet **nichts** zusätzlich: der Produktions-Build lief hier ohnehin schon, es kommt nur der Vergleich dahinter.

## Abnahme

- projektwerk `b50e137` (reine Typ-/Kommentaränderung) läuft durch — mit demselben Verfahren über `nc-bundle-fresh` belegt
- contractmanager `29e21c9` (dompurify-Bump ohne Rebuild, der echte Fund) wird abgewiesen
- Ein Bundle aus einem fremden Stand wird abgewiesen — heute bestand es die Prüfung
- Tests dafür liegen in cpcMomentum/nc-app-tooling und laufen dort in der CI