### PR TITLE
chore(deps): nc-app-tooling auf v1.11.0 (nc-bundle-check ausgebaut)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "babel-jest": "^29.7.0",
                 "eslint": "^8.57.0",
                 "jest": "^29.7.0",
-                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.10.0",
+                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.11.0",
                 "vue-loader": "^17.4.2",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^6.0.1"
@@ -13261,12 +13261,11 @@
             "license": "MIT"
         },
         "node_modules/nc-app-tooling": {
-            "version": "1.10.0",
-            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#a02d303cc01b2e24464c3cca87dacec04aea58ef",
+            "version": "1.11.0",
+            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#331f81df99bbd11f6f352fbcdfb8a87c48cfc9ec",
             "dev": true,
             "license": "AGPL-3.0-or-later",
             "bin": {
-                "nc-bundle-check": "bin/bundle-check.mjs",
                 "nc-bundle-fresh": "bin/bundle-fresh.mjs",
                 "nc-l10n-check": "bin/l10n-check.mjs",
                 "nc-pre-commit": "bin/pre-commit.mjs",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "babel-jest": "^29.7.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
-        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.10.0",
+        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.11.0",
         "vue-loader": "^17.4.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^6.0.1"


### PR DESCRIPTION
Zieht `nc-app-tooling` von `v1.10.0` auf `v1.11.0` nach.

**BREAKING dort:** `nc-bundle-check` ist entfernt. Diese App ruft ihn seit cpcMomentum/nc-app-tooling#1 nicht mehr auf — der Vergleich steht jetzt als `git status --porcelain -- js/ css/` hinter dem Produktions-Build in `node.yml`. Der Bump räumt damit nur noch die tote Abhängigkeit weg.

`nc-l10n-check`, `nc-pre-commit`, `nc-release-check` und `nc-bundle-fresh` bleiben unverändert.

Geprüft: nach `npm install` ist `nc-bundle-check` aus `node_modules/.bin` verschwunden, `nc-bundle-fresh` weiterhin da.