### PR TITLE
workingDaysPerWeek profil-eigen + Anlegen respektiert Tageszahl (Teil 2 von #573)

### DIFF
--- a/lib/Controller/EmployeeController.php
+++ b/lib/Controller/EmployeeController.php
@@ -134,7 +134,6 @@ class EmployeeController extends BaseController {
         string $federalState = 'BY',
         ?string $entryDate = null,
         ?string $exitDate = null,
-        int $workingDaysPerWeek = 5,
         ?float $vacationDaysUsed = null
     ): JSONResponse {
         if ($authError = $this->requireAuth()) {
@@ -157,7 +156,6 @@ class EmployeeController extends BaseController {
                 $entryDate,
                 $exitDate,
                 $this->userId,
-                $workingDaysPerWeek,
                 $vacationDaysUsed
             );
 

--- a/lib/Service/EmployeeService.php
+++ b/lib/Service/EmployeeService.php
@@ -242,7 +242,6 @@ class EmployeeService {
         ?string $entryDate = null,
         ?string $exitDate = null,
         string $currentUserId = '',
-        int $workingDaysPerWeek = 5,
         ?float $vacationDaysUsed = null
     ): Employee {
         $employee = $this->find($id);
@@ -261,16 +260,18 @@ class EmployeeService {
             throw ValidationException::fromSingleError('supervisorId', 'Employee cannot be their own supervisor');
         }
 
-        // weeklyHours and vacationDays are intentionally not set here: they are
-        // owned by the work schedule profile and synced via
-        // WorkScheduleService::syncEmployeeFromActiveSchedule. Surfacing them on
-        // read happens in withActiveSchedule().
+        // weeklyHours, vacationDays and workingDaysPerWeek are intentionally not
+        // set here: they are owned by the work schedule profile and mirrored onto
+        // the employee via applyScheduleValues() on every read (withActiveSchedule).
+        // #573: workingDaysPerWeek used to be written from the client payload here,
+        // a dead control path - the field is derived from the profile day pattern
+        // and the editor shows it read-only since #571, so the persisted value was
+        // always shadowed on the next read anyway.
         $employee->setFirstName($firstName);
         $employee->setLastName($lastName);
         $employee->setEmail($email);
         $employee->setPersonnelNumber($personnelNumber);
         $employee->setSupervisorId($supervisorId);
-        $employee->setWorkingDaysPerWeek(max(1, min(7, $workingDaysPerWeek)));
         $employee->setFederalState($federalState);
 
         $employee->setEntryDate($entryDate ? new DateTime($entryDate) : null);
@@ -561,19 +562,30 @@ class EmployeeService {
      */
     private function createInitialWorkSchedule(Employee $employee): void {
         try {
-            $dailyHours = round((float)$employee->getWeeklyHours() / 5, 2);
+            // Respect the requested number of working days per week instead of
+            // always assuming Mon-Fri (#573): the first N weekdays are worked at
+            // weeklyHours / N, the remaining days are off. N=5 reproduces the
+            // previous Mon-Fri behaviour unchanged.
+            $workingDays = max(1, min(7, $employee->getWorkingDaysPerWeek()));
+            $dailyHours = round((float)$employee->getWeeklyHours() / $workingDays, 2);
+            $formatted = number_format($dailyHours, 2, '.', '');
             $validFrom = $employee->getEntryDate() ?? new DateTime('2020-01-01');
+
+            $hours = array_fill(0, 7, '0.00');
+            for ($i = 0; $i < $workingDays; $i++) {
+                $hours[$i] = $formatted;
+            }
 
             $schedule = new \OCA\WorkTime\Db\WorkSchedule();
             $schedule->setEmployeeId($employee->getId());
             $schedule->setValidFrom($validFrom);
-            $schedule->setMonHours(number_format($dailyHours, 2, '.', ''));
-            $schedule->setTueHours(number_format($dailyHours, 2, '.', ''));
-            $schedule->setWedHours(number_format($dailyHours, 2, '.', ''));
-            $schedule->setThuHours(number_format($dailyHours, 2, '.', ''));
-            $schedule->setFriHours(number_format($dailyHours, 2, '.', ''));
-            $schedule->setSatHours('0.00');
-            $schedule->setSunHours('0.00');
+            $schedule->setMonHours($hours[0]);
+            $schedule->setTueHours($hours[1]);
+            $schedule->setWedHours($hours[2]);
+            $schedule->setThuHours($hours[3]);
+            $schedule->setFriHours($hours[4]);
+            $schedule->setSatHours($hours[5]);
+            $schedule->setSunHours($hours[6]);
             $schedule->setVacationDays($employee->getVacationDays());
             $schedule->setCreatedAt(new DateTime());
             $schedule->setUpdatedAt(new DateTime());

--- a/tests/Unit/Service/EmployeeServiceTest.php
+++ b/tests/Unit/Service/EmployeeServiceTest.php
@@ -266,4 +266,101 @@ class EmployeeServiceTest extends TestCase {
         $this->expectException(\OCA\WorkTime\Service\ValidationException::class);
         $this->service->updateMyDeputy('user2', 2);
     }
+
+    // ---------------------------------------------------------------------
+    // #573: workingDaysPerWeek is owned by the profile day pattern
+    // ---------------------------------------------------------------------
+
+    /**
+     * The initial work schedule must honour the requested working days per week
+     * (#573): a 4-day week produces a Mon-Thu profile at weeklyHours / 4, not the
+     * old hard-coded Mon-Fri at weeklyHours / 5.
+     */
+    public function testCreateInitialScheduleHonoursWorkingDaysPerWeek(): void {
+        $this->employeeMapper->method('existsByUserId')->willReturn(false);
+        $this->employeeMapper->method('insert')->willReturnCallback(
+            function (Employee $e): Employee {
+                $e->setId(9);
+                return $e;
+            }
+        );
+
+        $captured = null;
+        $this->workScheduleMapper->method('insert')->willReturnCallback(
+            function (WorkSchedule $s) use (&$captured): WorkSchedule {
+                $captured = $s;
+                return $s;
+            }
+        );
+
+        // 30h across 4 days => 7.5h on Mon-Thu, nothing Fri-Sun.
+        $this->service->create('user9', 'Nina', 'Vier', null, null, 30.0, 24, null, 'BY', null, 'admin', 4);
+
+        $this->assertNotNull($captured, 'initial work schedule must be persisted');
+        $this->assertSame(7.5, (float)$captured->getMonHours());
+        $this->assertSame(7.5, (float)$captured->getTueHours());
+        $this->assertSame(7.5, (float)$captured->getWedHours());
+        $this->assertSame(7.5, (float)$captured->getThuHours());
+        $this->assertSame(0.0, (float)$captured->getFriHours());
+        $this->assertSame(0.0, (float)$captured->getSatHours());
+        $this->assertSame(0.0, (float)$captured->getSunHours());
+        $this->assertSame(4, $captured->getWorkingDaysPerWeek());
+    }
+
+    /**
+     * A 5-day week keeps the previous Mon-Fri / weeklyHours-÷-5 behaviour
+     * unchanged (regression guard for the default path).
+     */
+    public function testCreateInitialScheduleFiveDayWeekUnchanged(): void {
+        $this->employeeMapper->method('existsByUserId')->willReturn(false);
+        $this->employeeMapper->method('insert')->willReturnCallback(
+            function (Employee $e): Employee {
+                $e->setId(10);
+                return $e;
+            }
+        );
+
+        $captured = null;
+        $this->workScheduleMapper->method('insert')->willReturnCallback(
+            function (WorkSchedule $s) use (&$captured): WorkSchedule {
+                $captured = $s;
+                return $s;
+            }
+        );
+
+        $this->service->create('user10', 'Erik', 'Fünf', null, null, 40.0, 30, null, 'BY', null, 'admin', 5);
+
+        $this->assertNotNull($captured);
+        $this->assertSame(8.0, (float)$captured->getMonHours());
+        $this->assertSame(8.0, (float)$captured->getFriHours());
+        $this->assertSame(0.0, (float)$captured->getSatHours());
+        $this->assertSame(5, $captured->getWorkingDaysPerWeek());
+    }
+
+    /**
+     * update() no longer accepts workingDaysPerWeek from the client (#573). The
+     * value surfaced on the returned employee must come from the active profile's
+     * day pattern (here 4 days), never a stale persisted entity value.
+     */
+    public function testUpdateDerivesWorkingDaysPerWeekFromProfile(): void {
+        $employee = $this->makeEmployee(5, '30.00', 24);
+        $employee->setWorkingDaysPerWeek(7); // stale value that must be ignored
+        $this->employeeMapper->method('find')->willReturn($employee);
+        $this->employeeMapper->method('update')->willReturnArgument(0);
+
+        $fourDay = new WorkSchedule();
+        $fourDay->setMonHours('7.50');
+        $fourDay->setTueHours('7.50');
+        $fourDay->setWedHours('7.50');
+        $fourDay->setThuHours('7.50');
+        $fourDay->setFriHours('0.00');
+        $fourDay->setSatHours('0.00');
+        $fourDay->setSunHours('0.00');
+        $fourDay->setVacationDays(24);
+        $this->workScheduleService->method('getScheduleForDate')->willReturn($fourDay);
+
+        $result = $this->service->update(5, 'Nina', 'Vier', null, null, null, 'BY', null, null, 'admin', null);
+
+        $this->assertSame(4, $result->getWorkingDaysPerWeek());
+    }
 }


### PR DESCRIPTION
Teil 2 von #573 (Feldsemantik-Nacharbeiten). Reiner Backend-Cleanup, keine UI-/l10n-Aenderung.

## Was

- **`workingDaysPerWeek` aus dem Update-Payload entfernt** (`EmployeeController::update` + `EmployeeService::update`). Toter Steuerpfad seit #571: das Feld ist im Bearbeiten-Modus read-only und wird beim Lesen ohnehin aus dem aktiven Profil gespiegelt (`applyScheduleValues`); der geschriebene Wert war auf dem naechsten Read stets ueberschattet und konnte nur vom Profil abdriften.
- **`createInitialWorkSchedule` respektiert jetzt `workingDaysPerWeek`** (Nebenbefund aus dem #571-RCA): die ersten N Wochentage werden mit `weeklyHours / N` belegt, der Rest ist frei. `N=5` reproduziert das bisherige Mo-Fr unveraendert. Eine 4-Tage-Woche erzeugt nicht mehr faelschlich ein Mo-Fr-Profil.

## Bewusst NICHT enthalten

- **Spalte `working_days_per_week` bleibt.** Verifiziert repo-weit: einziger Leser ist `ReportController` (dailyMinutes), und der liest den profil-abgeleiteten Wert via `find()`. Kein `SELECT/WHERE/ORDER BY` auf die Spalte. Sie ist funktional tot, ein Drop braechte aber null funktional bei realem QBMapper-Risiko (virtuelles Attribut + Migration).
- **Teil 1 von #573 (Zwoelftelung bei Ein-/Austritt)** folgt in eigenem PR. #573 bleibt offen.

## Test

- Unit-Suite gruen (332 Tests); 3 neue Tests: 4-Tage-Anlegen -> Mo-Do @ weeklyHours/4, 5-Tage-Anlegen unveraendert, Update leitet den Wert aus dem Profil ab.
- Mutationsprobe: Fix auf `/5` zurueckgedreht -> neuer Test wird rot (6.0 statt 7.5).
- PHP-Lint sauber, keine `OC\*`, Pre-Commit-l10n konsistent (keine Drift).
- Live auf Dev-Instanz durchgeklickt (Anlegen 4-Tage -> Mo-Do-Profil; Bearbeiten stabil).

Refs #573