### PR TITLE
Urlaubsanspruch bei Ein-/Austritt unterjährig zwölfteln (Teil 1 von #573)

### DIFF
--- a/lib/Service/WorkScheduleService.php
+++ b/lib/Service/WorkScheduleService.php
@@ -453,11 +453,8 @@ class WorkScheduleService {
 
         try {
             $employee = $this->employeeMapper->find($employeeId);
-        } catch (\Exception) {
+        } catch (DoesNotExistException) {
             return [$start, $end]; // no employee record: fall back to the full year
-        }
-        if (!$employee instanceof Employee) {
-            return [$start, $end];
         }
 
         $entry = $employee->getEntryDate();

--- a/lib/Service/WorkScheduleService.php
+++ b/lib/Service/WorkScheduleService.php
@@ -401,15 +401,32 @@ class WorkScheduleService {
      * #281 avoided a blend - it disagreed with the per-profile editor - is
      * resolved by reading each profile's value as its own full-year entitlement
      * and labelling the year total as a distinct figure.
+     *
+     * #573: the accrual window is additionally clipped to the employee's entry
+     * and exit dates, so a mid-year entry or exit prorates the entitlement
+     * (§ 5 Abs. 1 BUrlG). The denominator stays the full year, so the same
+     * working-day weighting handles employment period and pensum change alike.
      */
     public function getVacationEntitlementForYear(int $employeeId, int $year): float {
         $yearStart = new DateTime("$year-01-01");
         $yearEnd = new DateTime("$year-12-31");
 
+        // Only accrue leave for the part of the year the employee is actually
+        // employed (#573). The § 4 waiting period and the statutory/contractual
+        // split are deliberately not modelled: the whole entitlement is prorated
+        // uniformly.
+        [$windowStart, $windowEnd] = $this->employmentWindow($employeeId, $yearStart, $yearEnd);
+        if ($windowStart > $windowEnd) {
+            return 0.0; // not employed at any point during the year
+        }
+
         $total = 0.0;
-        foreach ($this->buildSegments($employeeId, $yearStart, $yearEnd) as $segment) {
+        foreach ($this->buildSegments($employeeId, $windowStart, $windowEnd) as $segment) {
             /** @var WorkSchedule $schedule */
             $schedule = $segment['schedule'];
+            // Denominator is the full year of this pattern, so the segment's
+            // share reflects both a shorter employment period and a smaller
+            // day pattern.
             $workingDaysFullYear = $this->countScheduledWorkingDays($schedule, $yearStart, $yearEnd);
             if ($workingDaysFullYear <= 0) {
                 continue; // a profile without working days carries no entitlement
@@ -419,6 +436,47 @@ class WorkScheduleService {
         }
 
         return $total;
+    }
+
+    /**
+     * The [start, end] sub-window of [yearStart, yearEnd] during which the
+     * employee is employed, clipped by entry and exit date (#573). A null entry
+     * or exit date means already/still employed on that side. If the employee
+     * only joined in a later year, or had already left before this year, the
+     * window is empty (start > end) and no entitlement accrues.
+     *
+     * @return array{0: DateTime, 1: DateTime}
+     */
+    private function employmentWindow(int $employeeId, DateTime $yearStart, DateTime $yearEnd): array {
+        $start = clone $yearStart;
+        $end = clone $yearEnd;
+
+        try {
+            $employee = $this->employeeMapper->find($employeeId);
+        } catch (\Exception) {
+            return [$start, $end]; // no employee record: fall back to the full year
+        }
+        if (!$employee instanceof Employee) {
+            return [$start, $end];
+        }
+
+        $entry = $employee->getEntryDate();
+        if ($entry !== null) {
+            $entry = (clone $entry)->setTime(0, 0, 0);
+            if ($entry > $start) {
+                $start = $entry;
+            }
+        }
+
+        $exit = $employee->getExitDate();
+        if ($exit !== null) {
+            $exit = (clone $exit)->setTime(0, 0, 0);
+            if ($exit < $end) {
+                $end = $exit;
+            }
+        }
+
+        return [$start, $end];
     }
 
     /**

--- a/tests/Unit/Service/WorkScheduleServiceTest.php
+++ b/tests/Unit/Service/WorkScheduleServiceTest.php
@@ -141,6 +141,84 @@ class WorkScheduleServiceTest extends TestCase {
     }
 
     // ---------------------------------------------------------------------
+    // #573: Zwölftelung bei Ein-/Austritt mitten im Jahr
+    // ---------------------------------------------------------------------
+
+    /**
+     * #573: joining mid-year only accrues leave for the employed part of the
+     * year. Entry 1 Jul with a full-time 5-day/30 profile yields ~15, not the
+     * full 30 the old full-year window granted via the default gap-fill.
+     */
+    public function testEntryMidYearProratesEntitlement(): void {
+        $pastYear = (int)(new DateTime())->format('Y') - 1;
+        $this->employeeMapper->method('find')
+            ->willReturn($this->employeeWithEntryDate($pastYear . '-07-01'));
+        $this->mapper->method('findByEmployeeAndDateRange')
+            ->willReturn([$this->scheduleAt($pastYear . '-07-01', 30, 5)]);
+
+        $entitlement = $this->service->getVacationEntitlementForYear(1, $pastYear);
+
+        $this->assertGreaterThan(0.0, $entitlement);
+        $this->assertLessThan(30.0, $entitlement);
+        $this->assertEqualsWithDelta(15.0, $entitlement, 1.0);
+    }
+
+    /**
+     * #573: leaving mid-year only accrues leave up to the exit date. A 5-day/30
+     * profile valid all year with exit 30 Jun yields ~15, not 30.
+     */
+    public function testExitMidYearProratesEntitlement(): void {
+        $pastYear = (int)(new DateTime())->format('Y') - 1;
+        $employee = $this->employeeWithEntryDate(null);
+        $employee->setExitDate(new DateTime($pastYear . '-06-30'));
+        $this->employeeMapper->method('find')->willReturn($employee);
+        $this->mapper->method('findByEmployeeAndDateRange')
+            ->willReturn([$this->scheduleAt(($pastYear - 5) . '-01-01', 30, 5)]);
+
+        $entitlement = $this->service->getVacationEntitlementForYear(1, $pastYear);
+
+        $this->assertGreaterThan(0.0, $entitlement);
+        $this->assertLessThan(30.0, $entitlement);
+        $this->assertEqualsWithDelta(15.0, $entitlement, 1.0);
+    }
+
+    /**
+     * #573 + #571 compose: entry 1 Apr, then a pensum change to full time on
+     * 1 Jul. Only Apr-Dec accrues, and within that the 4-day and 5-day segments
+     * are weighted separately (~21), clearly below the old full-year 30 and
+     * below a full year of either single profile.
+     */
+    public function testEntryAndPensumChangeComposeInSameYear(): void {
+        $pastYear = (int)(new DateTime())->format('Y') - 1;
+        $this->employeeMapper->method('find')
+            ->willReturn($this->employeeWithEntryDate($pastYear . '-04-01'));
+        $this->mapper->method('findByEmployeeAndDateRange')->willReturn([
+            $this->scheduleAt($pastYear . '-04-01', 24, 4), // Apr-Jun: 4-day week
+            $this->scheduleAt($pastYear . '-07-01', 30, 5), // Jul-Dec: full time
+        ]);
+
+        $entitlement = $this->service->getVacationEntitlementForYear(1, $pastYear);
+
+        $this->assertLessThan(24.0, $entitlement);
+        $this->assertEqualsWithDelta(21.0, $entitlement, 3.0);
+    }
+
+    /**
+     * #573: an employee who only joins in a later year accrues nothing for this
+     * year, even if a profile row exists.
+     */
+    public function testNotEmployedDuringYearYieldsZero(): void {
+        $pastYear = (int)(new DateTime())->format('Y') - 1;
+        $this->employeeMapper->method('find')
+            ->willReturn($this->employeeWithEntryDate(($pastYear + 1) . '-01-01'));
+        $this->mapper->method('findByEmployeeAndDateRange')
+            ->willReturn([$this->scheduleAt(($pastYear + 1) . '-01-01', 30, 5)]);
+
+        $this->assertSame(0.0, $this->service->getVacationEntitlementForYear(1, $pastYear));
+        $this->assertSame(0, $this->service->getVacationDaysForYear(1, $pastYear));
+    }
+
+    // ---------------------------------------------------------------------
     // #453: Rückdatierung von Arbeitszeitprofilen
     // ---------------------------------------------------------------------
 


### PR DESCRIPTION
Teil 1 von #573 (§ 5 Abs. 1 BUrlG). Schließt #573 ab (Teil 2 = #578 bereits gemergt).

## Was

`WorkScheduleService::getVacationEntitlementForYear` kappt das Rechenfenster auf den im Jahr **beschäftigten** Zeitraum `[max(1.1., entryDate), min(31.12., exitDate)]`. Der **Nenner bleibt das volle Jahr**, sodass jedes Profil mit `beschäftigte Arbeitstage / Arbeitstage-Volljahr` gewichtet wird — dieselbe Arbeitstagsgewichtung wie beim Pensumwechsel (#571). Damit komponiert Ein-/Austritt **und** Pensumwechsel im selben Jahr korrekt.

Neuer Helper `employmentWindow` (defensiv: kein Employee-Record → volles Jahr). Signatur `(employeeId, year)` unverändert, **kein Caller-Change**.

## RCA (was vorher falsch war)

- **Eintrittsjahr:** `buildSegments` füllte die Lücke vor dem ersten Profil mit dem Default-Profil (30 Tage, Mo–Fr) → voller Jahresanspruch trotz Eintritt zur Jahresmitte.
- **Austrittsjahr:** das letzte Segment endete immer am 31.12., unabhängig von `exitDate` → voller Anspruch trotz Austritt.

## Bewusste Grenzen (abgestimmt)

- § 4 Wartezeit (6 Monate) und der Split gesetzlicher/vertraglicher Urlaub **nicht** modelliert — einheitlich anteilig.
- Der #522-Abzug „bereits verbraucht" bleibt unverändert (greift nur im Eintrittsjahr); im Eintrittsjahr wirken anteiliger Anspruch **und** #522-Abzug (bewusste Entscheidung).

## Migrationspfad Bestandsinstanzen

- **Keine DB-/Schema-Migration** — der Anspruch wird live aus Profilen + entry/exit gerechnet.
- Angezeigte Quoten für unterjährige Ein-/Austritte sinken beim Deploy sofort auf den anteiligen Wert (die beabsichtigte Korrektur).
- **Kein Kaskadenrisiko:** der Jahresübertrag ist ein gespeicherter Schnappschuss (`wt_yearly_carryover`) und rechnet nicht neu → Folgesalden bleiben stabil. Restrisiko rein kosmetisch (vergangenes Eintrittsjahr kann rückwirkend eine Überziehung anzeigen).

## Test

- 336 Unit-Tests grün; 4 neue: Eintritt→~15, Austritt→~15, Eintritt+Pensumwechsel→~21, nicht-beschäftigt→0.
- Mutationsprobe: Fenster-Kappung entfernt → Austrittstest rot (30 statt ~15).
- **Live an der Dev-Instanz** (Wegwerf-Mitarbeiter, danach über #424-Löschpfad entfernt): Eintritt 01.07.2025 → 2025=**15** / 2026=**30**; Austritt 30.06.2026 → 2026=**15**.

Fixes #573