### PR TITLE
fix(employees): Anzeige zeigt Profilwerte bei zukünftigem Eintrittsdatum (#581)

### DIFF
--- a/lib/Service/EmployeeService.php
+++ b/lib/Service/EmployeeService.php
@@ -56,7 +56,9 @@ class EmployeeService {
     private function withActiveSchedule(Employee $employee): Employee {
         return $this->applyScheduleValues(
             $employee,
-            $this->workScheduleService->getScheduleForDate($employee->getId(), new DateTime()),
+            // #581: show the earliest profile for a not-yet-started employee
+            // instead of the synthetic 40h/30 default.
+            $this->workScheduleService->getDisplaySchedule($employee->getId()),
         );
     }
 

--- a/lib/Service/EmployeeService.php
+++ b/lib/Service/EmployeeService.php
@@ -80,7 +80,7 @@ class EmployeeService {
         return array_map(
             fn (Employee $e): Employee => isset($active[$e->getId()])
                 ? $this->applyScheduleValues($e, $active[$e->getId()])
-                : $this->withActiveSchedule($e), // schedule-less employee: use default fallback
+                : $this->withActiveSchedule($e), // no profile active today: resolve via getDisplaySchedule (#581)
             $employees,
         );
     }

--- a/lib/Service/WorkScheduleService.php
+++ b/lib/Service/WorkScheduleService.php
@@ -76,6 +76,40 @@ class WorkScheduleService {
     }
 
     /**
+     * Schedule to SHOW for an employee today (#581).
+     *
+     * Unlike getScheduleForDate(), which returns the synthetic 40h/30 default as
+     * soon as no profile is active *today*, this prefers the employee's earliest
+     * profile when they only have future-dated ones - e.g. a new hire whose entry
+     * date (and therefore the initial profile's valid_from) lies ahead. Without
+     * this, the overview would show 40h/30 until the entry date is reached and the
+     * employee could appear to have more leave than they do.
+     *
+     * Display only: the calculation paths (buildSegments, calculateTargetMinutes)
+     * keep using getScheduleForDate() unchanged, so Soll and entitlement - which
+     * already clip by entry/exit date elsewhere - are untouched.
+     */
+    public function getDisplaySchedule(int $employeeId): WorkSchedule {
+        try {
+            return $this->mapper->findForDate($employeeId, new DateTime());
+        } catch (DoesNotExistException) {
+            // No profile active today - fall back to the earliest one if any exist.
+        }
+
+        $schedules = $this->mapper->findByEmployeeId($employeeId);
+        if (!empty($schedules)) {
+            usort(
+                $schedules,
+                static fn (WorkSchedule $a, WorkSchedule $b): int => $a->getValidFrom() <=> $b->getValidFrom(),
+            );
+            return $schedules[0];
+        }
+
+        // Truly profile-less employee: keep the synthetic default.
+        return $this->getScheduleForDate($employeeId, new DateTime());
+    }
+
+    /**
      * @throws ValidationException
      */
     public function create(

--- a/tests/Unit/Service/EmployeeServiceTest.php
+++ b/tests/Unit/Service/EmployeeServiceTest.php
@@ -87,7 +87,7 @@ class EmployeeServiceTest extends TestCase {
         $colleague->setDeputyId(3);
 
         $this->employeeMapper->method('find')->willReturn($resting);
-        $this->workScheduleService->method('getScheduleForDate')
+        $this->workScheduleService->method('getDisplaySchedule')
             ->willReturn($this->makeSchedule(8.0, 30));
         $this->employeeMapper->method('findAllByDeputy')->with(3)->willReturn([$colleague]);
 
@@ -110,7 +110,7 @@ class EmployeeServiceTest extends TestCase {
     public function testSetRestingNormalisesBlankReasonToNull(): void {
         $employee = $this->makeEmployee(3, '40.00', 30);
         $this->employeeMapper->method('find')->willReturn($employee);
-        $this->workScheduleService->method('getScheduleForDate')
+        $this->workScheduleService->method('getDisplaySchedule')
             ->willReturn($this->makeSchedule(8.0, 30));
         $this->employeeMapper->method('findAllByDeputy')->willReturn([]);
         $this->employeeMapper->method('update')->willReturnArgument(0);
@@ -134,7 +134,7 @@ class EmployeeServiceTest extends TestCase {
         // find() enriches via withActiveSchedule(); without this stub the mocked
         // schedule returns null and the entity setter throws a TypeError before
         // the validation under test is ever reached.
-        $this->workScheduleService->method('getScheduleForDate')
+        $this->workScheduleService->method('getDisplaySchedule')
             ->willReturn($this->makeSchedule(8.0, 30));
         $this->employeeMapper->method('findAllByDeputy')->with(3)->willReturn([$colleague]);
         $this->employeeMapper->expects($this->never())->method('update');
@@ -149,7 +149,7 @@ class EmployeeServiceTest extends TestCase {
         $employee->setLockedReason('Elternzeit');
 
         $this->employeeMapper->method('find')->willReturn($employee);
-        $this->workScheduleService->method('getScheduleForDate')
+        $this->workScheduleService->method('getDisplaySchedule')
             ->willReturn($this->makeSchedule(8.0, 30));
         $this->employeeMapper->method('update')->willReturnArgument(0);
 
@@ -174,7 +174,7 @@ class EmployeeServiceTest extends TestCase {
         // Cache holds 40h / 30 days, but the schedule active today is 31.5h / 28 days.
         $this->employeeMapper->method('find')
             ->willReturn($this->makeEmployee(6, '40.00', 30));
-        $this->workScheduleService->method('getScheduleForDate')
+        $this->workScheduleService->method('getDisplaySchedule')
             ->willReturn($this->makeSchedule(6.3, 28)); // 6.3 * 5 = 31.5
 
         $employee = $this->service->find(6);
@@ -185,11 +185,11 @@ class EmployeeServiceTest extends TestCase {
 
     public function testFindIgnoresFutureProfileForOverview(): void {
         // Active profile today = 31.5h; a future-dated 40h profile must not leak
-        // into the overview. getScheduleForDate already returns the active one.
+        // into the overview. getDisplaySchedule returns the active one.
         $this->employeeMapper->method('find')
             ->willReturn($this->makeEmployee(6, '40.00', 30));
-        $this->workScheduleService->method('getScheduleForDate')
-            ->with(6, $this->isInstanceOf(DateTime::class))
+        $this->workScheduleService->method('getDisplaySchedule')
+            ->with(6)
             ->willReturn($this->makeSchedule(6.3, 28));
 
         $employee = $this->service->find(6);
@@ -242,7 +242,7 @@ class EmployeeServiceTest extends TestCase {
     public function testUpdateMyDeputyPersistsDeputyId(): void {
         $this->employeeMapper->method('findByUserId')->with('user2')->willReturn($this->makeEmployee(2, '40.00', 30));
         $this->employeeMapper->method('update')->willReturnArgument(0);
-        $this->workScheduleService->method('getScheduleForDate')->willReturn($this->makeSchedule(8.0, 30));
+        $this->workScheduleService->method('getDisplaySchedule')->willReturn($this->makeSchedule(8.0, 30));
 
         $result = $this->service->updateMyDeputy('user2', 7);
 
@@ -252,7 +252,7 @@ class EmployeeServiceTest extends TestCase {
     public function testUpdateMyDeputyCanBeCleared(): void {
         $this->employeeMapper->method('findByUserId')->with('user2')->willReturn($this->makeEmployee(2, '40.00', 30));
         $this->employeeMapper->method('update')->willReturnArgument(0);
-        $this->workScheduleService->method('getScheduleForDate')->willReturn($this->makeSchedule(8.0, 30));
+        $this->workScheduleService->method('getDisplaySchedule')->willReturn($this->makeSchedule(8.0, 30));
 
         $result = $this->service->updateMyDeputy('user2', null);
 
@@ -261,7 +261,7 @@ class EmployeeServiceTest extends TestCase {
 
     public function testUpdateMyDeputyRejectsSelf(): void {
         $this->employeeMapper->method('findByUserId')->with('user2')->willReturn($this->makeEmployee(2, '40.00', 30));
-        $this->workScheduleService->method('getScheduleForDate')->willReturn($this->makeSchedule(8.0, 30));
+        $this->workScheduleService->method('getDisplaySchedule')->willReturn($this->makeSchedule(8.0, 30));
 
         $this->expectException(\OCA\WorkTime\Service\ValidationException::class);
         $this->service->updateMyDeputy('user2', 2);
@@ -357,7 +357,7 @@ class EmployeeServiceTest extends TestCase {
         $fourDay->setSatHours('0.00');
         $fourDay->setSunHours('0.00');
         $fourDay->setVacationDays(24);
-        $this->workScheduleService->method('getScheduleForDate')->willReturn($fourDay);
+        $this->workScheduleService->method('getDisplaySchedule')->willReturn($fourDay);
 
         $result = $this->service->update(5, 'Nina', 'Vier', null, null, null, 'BY', null, null, 'admin', null);
 

--- a/tests/Unit/Service/WorkScheduleServiceTest.php
+++ b/tests/Unit/Service/WorkScheduleServiceTest.php
@@ -219,6 +219,54 @@ class WorkScheduleServiceTest extends TestCase {
     }
 
     // ---------------------------------------------------------------------
+    // #581: Anzeige-Profil bei zukünftigem Eintrittsdatum
+    // ---------------------------------------------------------------------
+
+    /**
+     * #581: when a profile is active today it is used as-is for the display.
+     */
+    public function testGetDisplayScheduleReturnsActiveToday(): void {
+        $this->mapper->method('findForDate')->willReturn($this->scheduleAt('2020-01-01', 25, 5));
+
+        $this->assertSame(25, $this->service->getDisplaySchedule(1)->getVacationDays());
+    }
+
+    /**
+     * #581: a not-yet-started employee (only future-dated profiles, e.g. entry
+     * date ahead) must show their EARLIEST profile, not the synthetic 40h/30
+     * default. This is the reported bug: the overview showed 30 until the entry
+     * date was reached.
+     */
+    public function testGetDisplayScheduleFallsBackToEarliestFutureProfile(): void {
+        $this->mapper->method('findForDate')
+            ->willThrowException(new DoesNotExistException('no active profile today'));
+        $this->mapper->method('findByEmployeeId')->willReturn([
+            $this->scheduleAt('2099-06-01', 20, 4), // later
+            $this->scheduleAt('2099-01-01', 12, 2), // earliest -> must win
+        ]);
+
+        $result = $this->service->getDisplaySchedule(1);
+
+        $this->assertSame(12, $result->getVacationDays(), 'earliest profile must win, not the default 30');
+        $this->assertSame('2099-01-01', $result->getValidFrom()->format('Y-m-d'));
+    }
+
+    /**
+     * #581: an employee with no profile at all still falls back to the synthetic
+     * default (40h / 30).
+     */
+    public function testGetDisplayScheduleFallsBackToDefaultWhenNoProfiles(): void {
+        $this->mapper->method('findForDate')
+            ->willThrowException(new DoesNotExistException('none'));
+        $this->mapper->method('findByEmployeeId')->willReturn([]);
+
+        $result = $this->service->getDisplaySchedule(1);
+
+        $this->assertSame(30, $result->getVacationDays());
+        $this->assertSame(40.0, (float)$result->getWeeklyHours());
+    }
+
+    // ---------------------------------------------------------------------
     // #453: Rückdatierung von Arbeitszeitprofilen
     // ---------------------------------------------------------------------
 


### PR DESCRIPTION
Behebt #581 (Bug gemeldet von Jana Grieb / oase-rottenburg). RCA lokal: `docs/rca/20260816_neuer-mitarbeiter-anzeige-default-bei-zukuenftigem-eintritt.md`.

## Symptom
Neu angelegter Mitarbeiter mit **zukünftigem Eintrittsdatum** zeigte in der oberen Anzeige (Übersicht/Editor, auch beim MA selbst) die synthetischen Standardwerte **40h/30** statt der eingetragenen Werte — bis heute das Eintrittsdatum erreicht war, dann sprang es „ohne Zutun" um. Folge: der MA konnte mehr Urlaub beantragen als zusteht.

## Root Cause
`EmployeeService::withActiveSchedule` leitet die Anzeige aus `getScheduleForDate(heute)` ab. Ist das einzige Profil erst künftig gültig (`valid_from = Eintrittsdatum`), findet `findForDate(heute)` nichts → `getScheduleForDate` liefert das synthetische Default-Profil (40h/30). Der Default-Fallback vermischt „noch nicht gültig" mit „gar kein Profil".

## Fix (Ansatz A, zielgerichtet)
Neue Methode `WorkScheduleService::getDisplaySchedule()`: **heute aktiv → sonst frühestes Profil → sonst Default**. `withActiveSchedule` nutzt sie. Die Rechenpfade (`buildSegments`, `calculateTargetMinutes`) bleiben auf `getScheduleForDate` — Soll und Anspruch kappen bereits anderweitig nach entry/exit (`OvertimeCalculationService`, #573), sind also nicht betroffen.

## Bewusst nicht enthalten
Kein „ab TT.MM."-Hinweis in der Anzeige (reine UX-Kür, kann separat kommen). Angezeigt werden die echten Profilwerte.

## Test
- 339 Unit-Tests grün; 3 neue für `getDisplaySchedule` (aktiv-heute / frühestes-Zukunftsprofil / kein-Profil→Default). Die `EmployeeServiceTest`-Display-Stubs von `getScheduleForDate` auf `getDisplaySchedule` umgezogen.
- Mutationsprobe: Earliest-Fallback abgeschaltet → Zukunftsprofil-Test rot (30 statt 12).
- Lint sauber, keine `OC\*`, l10n konsistent (keine neuen Strings).
- **Live an der Dev-Instanz** (Wegwerf-MA, danach über #424-Löschpfad + Nutzer entfernt): Eintritt 01.12.2026 + Profil 20h/12 → Anzeige zeigt 20h/12 (vorher 40/30).

Fixes #581