### PR TITLE
fix(notifications): deprecated InvalidArgumentException aus prepare() abfangen (#551)

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -37,6 +37,27 @@ class Notifier implements INotifier {
 			throw new UnknownNotificationException();
 		}
 
+		try {
+			return $this->prepareWorkTimeNotification($notification, $languageCode);
+		} catch (UnknownNotificationException $e) {
+			// Genuinely unknown subject — let NC handle it.
+			throw $e;
+		} catch (\InvalidArgumentException $e) {
+			// A known WorkTime notification whose stored parameters are no longer
+			// valid — typically a stale row written by an older app version. NC 34+
+			// deprecates letting \InvalidArgumentException escape prepare() (#551);
+			// discard the undisplayable notification cleanly so it stops
+			// re-spamming the log on every cron run.
+			throw new UnknownNotificationException();
+		}
+	}
+
+	/**
+	 * Build a known WorkTime notification. Any \InvalidArgumentException raised
+	 * while setting the parsed subject/message, icon or link (e.g. from stale
+	 * parameters or a missing route) is caught and handled by prepare().
+	 */
+	private function prepareWorkTimeNotification(INotification $notification, string $languageCode): INotification {
 		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
 		$params = $notification->getSubjectParameters();
 		$monthYear = $this->formatMonthYear($params, $languageCode);

--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace OCA\WorkTime\Tests\Unit\Notification;
 
+use OCA\WorkTime\AppInfo\Application;
 use OCA\WorkTime\Notification\Notifier;
+use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+use OCP\Notification\UnknownNotificationException;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -23,12 +27,69 @@ class NotifierTest extends TestCase {
     private Notifier $notifier;
 
     protected function setUp(): void {
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnCallback(
+            static fn (string $text): string => $text
+        );
+        $l10nFactory = $this->createMock(IFactory::class);
+        $l10nFactory->method('get')->willReturn($l10n);
+
         $this->notifier = new Notifier(
             $this->createMock(IURLGenerator::class),
-            $this->createMock(IFactory::class),
+            $l10nFactory,
         );
         $this->formatMonthYear = new ReflectionMethod(Notifier::class, 'formatMonthYear');
         $this->formatMonthYear->setAccessible(true);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function buildNotification(string $subject, array $params, bool $subjectThrows = false): INotification {
+        $notification = $this->createMock(INotification::class);
+        $notification->method('getApp')->willReturn(Application::APP_ID);
+        $notification->method('getSubject')->willReturn($subject);
+        $notification->method('getSubjectParameters')->willReturn($params);
+        if ($subjectThrows) {
+            // Mirrors NC's INotification setters, which validate their input and
+            // throw \InvalidArgumentException on an empty/oversized value.
+            $notification->method('setParsedSubject')->willThrowException(new \InvalidArgumentException('invalid subject'));
+        } else {
+            $notification->method('setParsedSubject')->willReturnSelf();
+        }
+        $notification->method('setParsedMessage')->willReturnSelf();
+        $notification->method('setIcon')->willReturnSelf();
+        $notification->method('setLink')->willReturnSelf();
+        return $notification;
+    }
+
+    public function testForeignAppNotificationIsUnknown(): void {
+        $notification = $this->createMock(INotification::class);
+        $notification->method('getApp')->willReturn('some_other_app');
+
+        $this->expectException(UnknownNotificationException::class);
+        $this->notifier->prepare($notification, 'de');
+    }
+
+    public function testUnknownSubjectIsUnknown(): void {
+        $this->expectException(UnknownNotificationException::class);
+        $this->notifier->prepare($this->buildNotification('subject_that_does_not_exist', []), 'de');
+    }
+
+    public function testKnownNotificationIsPrepared(): void {
+        $notification = $this->buildNotification('time_entries_approved', ['month' => 3, 'year' => 2026]);
+        $this->assertSame($notification, $this->notifier->prepare($notification, 'de'));
+    }
+
+    public function testStaleParametersAreDiscardedAsUnknown(): void {
+        // #551: a known notification whose stored parameters no longer validate
+        // makes an NC setter throw \InvalidArgumentException. It must not escape
+        // prepare() (deprecated on NC 34+) — the undisplayable notification is
+        // discarded as unknown instead, so it stops re-spamming the log.
+        $notification = $this->buildNotification('time_entries_approved', ['month' => 3, 'year' => 2026], subjectThrows: true);
+
+        $this->expectException(UnknownNotificationException::class);
+        $this->notifier->prepare($notification, 'de');
     }
 
     /**


### PR DESCRIPTION
## Problem

Seit NC 34 loggt der Server im Minutentakt:

> OCA\WorkTime\Notification\Notifier::prepare() threw \InvalidArgumentException which is deprecated. Throw \OCP\Notification\UnknownNotificationException when the notification is not known to your notifier and otherwise handle all \InvalidArgumentException yourself.

Fixes #551

## RCA-Kern (siehe `docs/rca/20260817_issue551-notifier-invalidargument-deprecated.md`)

Die naheliegende Vermutung — ein eigener `throw new \InvalidArgumentException` — trifft **nicht** zu: Der Notifier wirft an den "unbekannt"-Stellen (Fremd-App, `default:`) bereits korrekt `UnknownNotificationException` (Z. 37/176), und das seit Erstanlage.

Die geloggte `\InvalidArgumentException` entsteht **innerhalb** von `prepare()` beim Aufbau einer *bekannten* Benachrichtigung: NCs `INotification`-Setter (`setParsedSubject/-Message`, `setIcon`, `setLink`) validieren ihre Eingaben und werfen bei ungueltigem Wert `\InvalidArgumentException`, die bisher ungefangen aus `prepare()` herauslief. Wahrscheinlichster Ausloeser: eine veraltete Benachrichtigungszeile in `oc_notifications`, die NC im Minutentakt neu aufzubauen versucht.

## Fix

- Aufbau der bekannten Benachrichtigung ausgelagert in `prepareWorkTimeNotification()`.
- `prepare()` faengt `\InvalidArgumentException` ab und verwirft die nicht darstellbare Benachrichtigung sauber als `UnknownNotificationException` (NC entfernt sie dann → Log-Spam endet).
- `UnknownNotificationException` (Fremd-App, unbekanntes Subject) laufen unveraendert durch — der `catch (UnknownNotificationException)` steht bewusst **vor** dem `catch (\InvalidArgumentException)`, da erstere von letzterer erbt.

## Tests

`tests/Unit/Notification/NotifierTest.php`: Fremd-App, unbekanntes Subject, Happy Path und der #551-Fall (Setter wirft IAE → `UnknownNotificationException`). Per Mutationstest verifiziert: ohne den Fix wird `testStaleParametersAreDiscardedAsUnknown` rot.

Kein Frontend-/Build-Anteil (reine PHP-Aenderung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)