### PR TITLE
fix(migration): vacation_transferred nullable — Update auf 0.16.0 bricht ab (#596)

### DIFF
--- a/lib/Migration/Version000025Date20260816000000.php
+++ b/lib/Migration/Version000025Date20260816000000.php
@@ -43,8 +43,16 @@ class Version000025Date20260816000000 extends SimpleMigrationStep {
         $table = $schema->getTable('wt_employees');
 
         if (!$table->hasColumn('vacation_transferred')) {
+            // #596: the column must be nullable. Nextcloud rejects a NOT NULL
+            // boolean column ("type Bool and also NotNull, so it can not store
+            // false") because false is treated as an empty value that a NOT NULL
+            // boolean cannot hold on every supported platform — the update aborts.
+            // A nullable boolean with a false default is the portable form: the
+            // DEFAULT backfills existing rows to false on ADD COLUMN, so no NULL
+            // ever reaches the (typed bool) entity, and postSchemaChange then
+            // flips the takeover rows to true.
             $table->addColumn('vacation_transferred', Types::BOOLEAN, [
-                'notnull' => true,
+                'notnull' => false,
                 'default' => false,
             ]);
         }


### PR DESCRIPTION
## Problem (Regression aus 0.16.0)

Das Update auf 0.16.0 bricht bei Migration `000025Date20260816000000` ab:

> Column "oc_wt_employees"."vacation_transferred" is type Bool and also NotNull, so it can not store "false".

Fixes #596

## Ursache

Die Migration legte `vacation_transferred` als `Types::BOOLEAN` mit `notnull => true` an. Nextcloud lehnt eine NOT-NULL-Boolean-Spalte ab (false gilt als Leerwert, den sie nicht auf jeder Plattform halten kann). Umgebungsabhaengig: auf manchen Instanzen (unsere Postgres-AIO) lief die Migration durch, bei anderen (neonblind) bricht sie ab — deshalb fing der Upgrade-Test es nicht.

Nebenbefund: alle anderen Ja/Nein-Spalten der App sind bewusst `SMALLINT`; `vacation_transferred` war die einzige echte Boolean-Spalte.

## Fix

`notnull => false` (nullable), `default => false` bleibt. Der DEFAULT backfillt bestehende Zeilen beim ADD COLUMN auf false, kein NULL erreicht die bool-typisierte Entity; postSchemaChange setzt danach die Uebernahme-Zeilen (entry_date IS NOT NULL) auf true. Spalte bleibt echte Boolean, Entity unveraendert.

### Warum nullable-Boolean statt SMALLINT, und 000025 editiert

Manche Instanzen haben 000025 bereits als BOOLEAN angewendet (laeuft dort nicht erneut). SMALLINT + Entity-integer wuerde deren Lesart brechen. Nullable-Boolean laesst die erfolgreichen Instanzen korrekt und repariert nur die abgebrochenen.

## Dringlichkeit

Blockiert das Update auf 0.16.0 fuer betroffene Instanzen, zeitnah als 0.16.1 raus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)