### PR TITLE
fix(notification): Icon als absolute URL setzen (#551)

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -43,19 +43,21 @@ class Notifier implements INotifier {
 			// Genuinely unknown subject — let NC handle it.
 			throw $e;
 		} catch (\InvalidArgumentException $e) {
-			// A known WorkTime notification whose stored parameters are no longer
-			// valid — typically a stale row written by an older app version. NC 34+
-			// deprecates letting \InvalidArgumentException escape prepare() (#551);
-			// discard the undisplayable notification cleanly so it stops
-			// re-spamming the log on every cron run.
+			// Safety net: an NC INotification setter rejected a value while
+			// building a known notification. The concrete #551 cause (a relative
+			// icon URL) is fixed above with getAbsoluteURL(), so this should no
+			// longer fire in normal operation; it stays to guard against any
+			// other setter rejection on a future NC version. NC 34+ deprecates
+			// letting \InvalidArgumentException escape prepare(), so convert it
+			// and discard the undisplayable notification cleanly.
 			throw new UnknownNotificationException();
 		}
 	}
 
 	/**
 	 * Build a known WorkTime notification. Any \InvalidArgumentException raised
-	 * while setting the parsed subject/message, icon or link (e.g. from stale
-	 * parameters or a missing route) is caught and handled by prepare().
+	 * by an NC setter while building it (e.g. a value NC rejects on a given
+	 * version) is caught and handled by prepare().
 	 */
 	private function prepareWorkTimeNotification(INotification $notification, string $languageCode): INotification {
 		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
@@ -197,8 +199,16 @@ class Notifier implements INotifier {
 				throw new UnknownNotificationException();
 		}
 
+		// #551: NC 34's setIcon() rejects anything that is not an absolute
+		// http(s) URL, and imagePath() returns a relative path. Passing the raw
+		// imagePath() throws InvalidValueException (⊂ \InvalidArgumentException),
+		// which aborts prepare() before setLink() — the notification then loses
+		// both its icon and its link (and NC 34 logs the throw on every cycle).
+		// Wrap it in getAbsoluteURL() so the icon is a valid absolute URL.
 		$notification->setIcon(
-			$this->urlGenerator->imagePath(Application::APP_ID, 'app-dark.svg')
+			$this->urlGenerator->getAbsoluteURL(
+				$this->urlGenerator->imagePath(Application::APP_ID, 'app-dark.svg')
+			)
 		);
 		$notification->setLink(
 			$this->urlGenerator->linkToRouteAbsolute('worktime.page.index')

--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -81,15 +81,52 @@ class NotifierTest extends TestCase {
         $this->assertSame($notification, $this->notifier->prepare($notification, 'de'));
     }
 
-    public function testStaleParametersAreDiscardedAsUnknown(): void {
-        // #551: a known notification whose stored parameters no longer validate
-        // makes an NC setter throw \InvalidArgumentException. It must not escape
-        // prepare() (deprecated on NC 34+) — the undisplayable notification is
-        // discarded as unknown instead, so it stops re-spamming the log.
+    public function testSetterRejectionIsDiscardedAsUnknown(): void {
+        // #551 safety net: if an NC INotification setter rejects a value while
+        // building a known notification, the resulting \InvalidArgumentException
+        // must not escape prepare() (deprecated on NC 34+). It is converted to
+        // UnknownNotificationException so the undisplayable notification is
+        // discarded cleanly instead of spamming the log every cron run.
         $notification = $this->buildNotification('time_entries_approved', ['month' => 3, 'year' => 2026], subjectThrows: true);
 
         $this->expectException(UnknownNotificationException::class);
         $this->notifier->prepare($notification, 'de');
+    }
+
+    public function testIconIsSetAsAbsoluteUrl(): void {
+        // #551 root cause: NC 34's setIcon() rejects a non-absolute URL, but
+        // imagePath() returns a relative path. The notifier must wrap it in
+        // getAbsoluteURL(); otherwise setIcon() throws and the notification
+        // loses both its icon and its link on NC 34. This locks the icon in as
+        // an absolute (http) URL so a regression to raw imagePath() fails here.
+        $urlGenerator = $this->createMock(IURLGenerator::class);
+        $urlGenerator->method('imagePath')
+            ->willReturn('/custom_apps/worktime/img/app-dark.svg');
+        $urlGenerator->method('getAbsoluteURL')
+            ->willReturnCallback(static fn (string $path): string => 'http://localhost' . $path);
+        $urlGenerator->method('linkToRouteAbsolute')
+            ->willReturn('http://localhost/apps/worktime/');
+
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+        $l10nFactory = $this->createMock(IFactory::class);
+        $l10nFactory->method('get')->willReturn($l10n);
+
+        $notifier = new Notifier($urlGenerator, $l10nFactory);
+
+        $notification = $this->createMock(INotification::class);
+        $notification->method('getApp')->willReturn(Application::APP_ID);
+        $notification->method('getSubject')->willReturn('time_entries_approved');
+        $notification->method('getSubjectParameters')->willReturn(['month' => 3, 'year' => 2026]);
+        $notification->method('setParsedSubject')->willReturnSelf();
+        $notification->method('setParsedMessage')->willReturnSelf();
+        $notification->method('setLink')->willReturnSelf();
+        $notification->expects($this->once())
+            ->method('setIcon')
+            ->with($this->stringStartsWith('http'))
+            ->willReturnSelf();
+
+        $notifier->prepare($notification, 'de');
     }
 
     /**


### PR DESCRIPTION
## Problem

Auf NC 34 fehlten **Icon und Link** in allen WorkTime-Benachrichtigungen, und NC loggte im Minutentakt eine Deprecation (der gemeldete #551-Spam).

## Ursache (bewiesen am NC-34-Kern)

`setIcon($urlGenerator->imagePath(...))` übergibt eine **relative** URL. NC 34's `setIcon()` verlangt eine absolute `http(s)://`-URL und wirft sonst `InvalidValueException` (⊂ `\InvalidArgumentException`). Der Wurf brach `prepare()` **vor** `setLink()` ab → Icon **und** Link gingen verloren; auf NC 34 wurde der Wurf zusätzlich als Deprecation geloggt. Datenunabhängig, jede Benachrichtigung.

Der 0.16.1-Fix (`try/catch`) hatte nur den Log-Spam stillgelegt, nicht die Ursache behoben.

## Fix

Icon via `getAbsoluteURL(imagePath(...))` setzen (wie projektwerk es bereits macht). Kein Wurf mehr → Icon und Link kommen zurück, Deprecation-Trigger verschwindet an der Quelle. Der `try/catch` bleibt als Sicherheitsnetz.

## Verifikation

- **Real-NC (NC 34):** `Manager::prepare()` für mehrere Subjects → Icon **und** Link nicht-leer, kein Wurf.
- **Unit:** neuer Regressionstest `testIconIsSetAsAbsoluteUrl` (setIcon erhält `http`-URL); per **Mutation** verifiziert, dass er bei rohem `imagePath` rot wird. Gesamte NotifierTest-Suite grün.
- PHP-only, kein Frontend-Build, keine sichtbaren Strings (keine l10n-Auswirkung).

## Kontext

- Root-Cause-Analyse: RCA-Dokument (lokal) + Kommentare in #551.
- Fleet-Prävention: nc-app-tooling#8. Gleicher Bug in contractmanager: contractmanager#357. projektwerk ist bereits korrekt.

Fixes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)