### PR TITLE
fix(punch): pause/resume race-sicher via atomarem UPDATE (#612)

### DIFF
--- a/lib/Db/ActivePunchMapper.php
+++ b/lib/Db/ActivePunchMapper.php
@@ -63,4 +63,46 @@ class ActivePunchMapper extends QBMapper {
 
 		return $qb->executeStatement();
 	}
+
+	/**
+	 * Atomically start a live break: set paused_at only if the punch is currently
+	 * running (paused_at IS NULL). Returns affected rows — 0 means it was already
+	 * paused (or gone). The row lock + WHERE re-evaluation serializes two
+	 * concurrent pause calls so only one wins (#612).
+	 *
+	 * @param string $nowUtc UTC timestamp formatted 'Y-m-d H:i:s'
+	 */
+	public function pauseIfRunning(int $id, string $nowUtc): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->update($this->getTableName())
+			->set('paused_at', $qb->createNamedParameter($nowUtc))
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->isNull('paused_at'));
+
+		return $qb->executeStatement();
+	}
+
+	/**
+	 * Atomically end a live break: add the elapsed seconds to break_seconds and
+	 * clear paused_at, only if a break is currently running (paused_at IS NOT
+	 * NULL). Returns affected rows — 0 means no break was running (already
+	 * resumed, or gone). The increment is done as column arithmetic in one
+	 * statement, so two concurrent resumes cannot double-count: the row lock
+	 * serializes them and the second sees paused_at already NULL → 0 affected
+	 * (#612). Portable across pgsql/mysql/sqlite (no datetime SQL functions).
+	 */
+	public function accumulateBreakAndResume(int $id, int $deltaSeconds): int {
+		$delta = max(0, $deltaSeconds);
+		$qb = $this->db->getQueryBuilder();
+		$qb->update($this->getTableName())
+			// func()->add() yields an IQueryFunction that set() passes through
+			// unquoted — a raw "break_seconds + :p" string would be quoted as a
+			// column name and break.
+			->set('break_seconds', $qb->func()->add('break_seconds', $qb->createNamedParameter($delta, IQueryBuilder::PARAM_INT)))
+			->set('paused_at', $qb->createNamedParameter(null, IQueryBuilder::PARAM_NULL))
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->isNotNull('paused_at'));
+
+		return $qb->executeStatement();
+	}
 }

--- a/lib/Service/PunchService.php
+++ b/lib/Service/PunchService.php
@@ -91,8 +91,12 @@ class PunchService {
 		if ($punch->isPaused()) {
 			throw new PunchConflictException($this->l->t('Die Stempelung ist bereits pausiert.'));
 		}
-		$punch->setPausedAt($this->nowUtc());
-		return $this->mapper->update($punch);
+		// Atomic conditional update (#612): two concurrent pauses serialize on the
+		// row lock; only one flips paused_at, the other gets 0 affected.
+		if ($this->mapper->pauseIfRunning($punch->getId(), $this->nowUtc()->format('Y-m-d H:i:s')) === 0) {
+			throw new PunchConflictException($this->l->t('Die Stempelung ist bereits pausiert.'));
+		}
+		return $this->requireOpen($employeeId);
 	}
 
 	/**
@@ -105,8 +109,15 @@ class PunchService {
 		if (!$punch->isPaused()) {
 			throw new PunchConflictException($this->l->t('Es läuft gerade keine Pause.'));
 		}
-		$this->foldRunningPause($punch);
-		return $this->mapper->update($punch);
+		// Accumulate the elapsed pause and clear paused_at in one atomic statement
+		// (#612): the delta is added as column arithmetic guarded on paused_at IS
+		// NOT NULL, so two concurrent resumes cannot double-count — the loser gets
+		// 0 affected.
+		$elapsed = $this->nowUtc()->getTimestamp() - $this->reinterpretAsUtc($punch->getPausedAt())->getTimestamp();
+		if ($this->mapper->accumulateBreakAndResume($punch->getId(), $elapsed) === 0) {
+			throw new PunchConflictException($this->l->t('Es läuft gerade keine Pause.'));
+		}
+		return $this->requireOpen($employeeId);
 	}
 
 	/**

--- a/tests/Unit/Service/PunchServiceTest.php
+++ b/tests/Unit/Service/PunchServiceTest.php
@@ -106,18 +106,51 @@ class PunchServiceTest extends TestCase {
 
 	// --- pause / resume ---------------------------------------------------
 
-	public function testResumeAccumulatesBreakSeconds(): void {
+	public function testPauseUsesAtomicConditionalUpdate(): void {
+		$punch = $this->punch($this->utc('2020-01-01 08:00:00'));
+		$this->mapper->method('findByEmployeeOrNull')->willReturn($punch);
+		// Atomic pause must run as a guarded UPDATE, not a read-then-update.
+		$this->mapper->expects($this->never())->method('update');
+		$this->mapper->expects($this->once())->method('pauseIfRunning')
+			->with(1, $this->isType('string'))->willReturn(1);
+
+		$result = $this->service->punchPause(7);
+		$this->assertInstanceOf(ActivePunch::class, $result);
+	}
+
+	public function testPauseLosingTheRaceThrowsConflict(): void {
+		$punch = $this->punch($this->utc('2020-01-01 08:00:00'));
+		$this->mapper->method('findByEmployeeOrNull')->willReturn($punch);
+		// A concurrent pause already flipped paused_at → 0 affected.
+		$this->mapper->method('pauseIfRunning')->willReturn(0);
+
+		$this->expectException(PunchConflictException::class);
+		$this->service->punchPause(7);
+	}
+
+	public function testResumeAccumulatesElapsedViaAtomicUpdate(): void {
 		$pausedAt = (new DateTime('now', new DateTimeZone('UTC')))->modify('-600 seconds');
 		$punch = $this->punch($this->utc('2020-01-01 08:00:00'), 100, $pausedAt);
 		$this->mapper->method('findByEmployeeOrNull')->willReturn($punch);
-		$this->mapper->method('update')->willReturnCallback(fn (ActivePunch $p): ActivePunch => $p);
+		$this->mapper->expects($this->never())->method('update');
+		// The elapsed pause (~600s) is added as column arithmetic, not in PHP.
+		$this->mapper->expects($this->once())->method('accumulateBreakAndResume')
+			->with(1, $this->callback(fn (int $d): bool => $d >= 599 && $d <= 602))
+			->willReturn(1);
 
 		$result = $this->service->punchResume(7);
+		$this->assertInstanceOf(ActivePunch::class, $result);
+	}
 
-		// 100 prior + ~600 elapsed; allow a couple of seconds of execution slack.
-		$this->assertGreaterThanOrEqual(699, $result->getBreakSeconds());
-		$this->assertLessThanOrEqual(603 + 100, $result->getBreakSeconds());
-		$this->assertNull($result->getPausedAt());
+	public function testResumeLosingTheRaceThrowsConflict(): void {
+		$pausedAt = (new DateTime('now', new DateTimeZone('UTC')))->modify('-600 seconds');
+		$punch = $this->punch($this->utc('2020-01-01 08:00:00'), 100, $pausedAt);
+		$this->mapper->method('findByEmployeeOrNull')->willReturn($punch);
+		// A concurrent resume already cleared paused_at → 0 affected, no double-count.
+		$this->mapper->method('accumulateBreakAndResume')->willReturn(0);
+
+		$this->expectException(PunchConflictException::class);
+		$this->service->punchResume(7);
 	}
 
 	public function testPauseWhenNotOpenThrowsConflict(): void {
@@ -129,6 +162,7 @@ class PunchServiceTest extends TestCase {
 	public function testPauseWhenAlreadyPausedThrowsConflict(): void {
 		$punch = $this->punch($this->utc('2020-01-01 08:00:00'), 0, $this->utc('2020-01-01 12:00:00'));
 		$this->mapper->method('findByEmployeeOrNull')->willReturn($punch);
+		$this->mapper->expects($this->never())->method('pauseIfRunning');
 		$this->expectException(PunchConflictException::class);
 		$this->service->punchPause(7);
 	}
@@ -136,6 +170,7 @@ class PunchServiceTest extends TestCase {
 	public function testResumeWhenNotPausedThrowsConflict(): void {
 		$punch = $this->punch($this->utc('2020-01-01 08:00:00'));
 		$this->mapper->method('findByEmployeeOrNull')->willReturn($punch);
+		$this->mapper->expects($this->never())->method('accumulateBreakAndResume');
 		$this->expectException(PunchConflictException::class);
 		$this->service->punchResume(7);
 	}


### PR DESCRIPTION
Befund aus dem Bot-Review von #609. Teil von #583.

## Problem
`punchPause`/`punchResume` lasen die offene Stempelung und schrieben `break_seconds`/`paused_at` zurück (read-then-update) **ohne Transaktion/Row-Lock** — anders als `punchOut`. Zwei nahezu gleichzeitige Resume-Aufrufe (Doppelklick, zwei Geräte) konnten die Pause **doppelt** in `break_seconds` verrechnen (lost update).

## Fix
Zustandswechsel als **atomare bedingte UPDATEs** im Mapper:
- `pauseIfRunning`: `SET paused_at=:now WHERE id=:id AND paused_at IS NULL`
- `accumulateBreakAndResume`: `SET break_seconds = break_seconds + :delta, paused_at = NULL WHERE id=:id AND paused_at IS NOT NULL`

Spaltenarithmetik über `func()->add()` (ein rohes `"break_seconds + :p"` würde von NCs `set()` als Spaltenname gequotet → Fehler), NULL über `PARAM_NULL`. **0 Affected → `PunchConflictException`**. Der Row-Lock serialisiert parallele Aufrufe; der Verlierer sieht den bereits geänderten Zustand → addiert nichts. Portabel über pgsql/mysql/sqlite (kein `EXTRACT`/`TIMESTAMPDIFF`).

`foldRunningPause` bleibt für den (bereits transaktionalen) punch-out-Pfad.

## Test
- Unit-Tests inkl. Race-Fälle (0 Affected → Conflict), **mutationsverifiziert**; volle Suite **369 grün**.
- **Integration am echten NC 34**: zwei gleichzeitige Resume → **[200, 409]**, Pause genau **einmal** gezählt (`break_seconds` 3→5 bei 2 s Pause); Pause-Race analog [200, 409]; normale Akkumulation via Spaltenarithmetik gegen Postgres bestätigt.

Kein l10n-Change (bestehende Konflikt-Meldungen), `l10n:check` konsistent.

Part of #583. Fixes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)