### PR TITLE
fix(report): PDF über Zeitraum ohne CSRF-Fehler (#620)

### DIFF
--- a/lib/Controller/ReportController.php
+++ b/lib/Controller/ReportController.php
@@ -606,6 +606,7 @@ class ReportController extends BaseController {
      * (#102), e.g. the 20th of one month to the 20th of the next.
      */
     #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function pdfRange(?int $employeeId = null, string $startDate = '', string $endDate = ''): DataDownloadResponse|JSONResponse {
         if ($authError = $this->requireAuth()) {
             return $authError;

--- a/tests/Unit/Controller/ReportControllerCsrfTest.php
+++ b/tests/Unit/Controller/ReportControllerCsrfTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Tests\Unit\Controller;
+
+use OCA\WorkTime\Controller\ReportController;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Prevention for #620: every file-download endpoint is opened via
+ * window.open() in the frontend — a direct browser navigation that carries no
+ * Nextcloud requesttoken — so each must be exempt from the CSRF check or NC
+ * rejects it ("CSRF check failed"). pdfRange() shipped without the attribute
+ * while its siblings had it; this test locks the attribute onto every download
+ * method so the omission cannot recur.
+ */
+class ReportControllerCsrfTest extends TestCase {
+
+	public function testEveryDownloadEndpointIsCsrfExempt(): void {
+		$class = new ReflectionClass(ReportController::class);
+		$checked = [];
+		foreach ($class->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+			if ($method->getDeclaringClass()->getName() !== ReportController::class) {
+				continue;
+			}
+			// A method that can return a DataDownloadResponse is a file download.
+			if (!str_contains((string)$method->getReturnType(), 'DataDownloadResponse')) {
+				continue;
+			}
+			$checked[] = $method->getName();
+			$this->assertNotEmpty(
+				$method->getAttributes(NoCSRFRequired::class),
+				sprintf(
+					'%s() returns a file download opened via window.open() and must carry #[NoCSRFRequired] (#620).',
+					$method->getName(),
+				),
+			);
+		}
+
+		// Guard against the reflection silently matching nothing and passing vacuously.
+		$this->assertGreaterThanOrEqual(
+			4,
+			count($checked),
+			'Expected at least the four known download endpoints (pdf, pdfRange, projectsPdf, projectsCsv); found: ' . implode(', ', $checked),
+		);
+	}
+}


### PR DESCRIPTION
Behebt #620 (extern gemeldet von Ben, v.haxthausen.net).

## Problem
„PDF über Zeitraum" → Nextcloud-Fehlerseite „Zugriff verboten – CSRF check failed". Monatsbericht funktioniert.

## Root Cause
`ReportController::pdfRange()` (GET `/api/reports/pdf-range`) fehlte `#[NoCSRFRequired]`. Das Frontend öffnet den Download per `window.open()` — direkte Browser-Navigation ohne `requesttoken` —, daher verwirft die CSRF-Middleware die Anfrage. Die Geschwister `pdf()`/`projectsPdf()`/`projectsCsv()` tragen das Attribut; `pdfRange` nie (Regression seit #102; `d0c82f3` hatte es für den Monatsbericht gelöst).

## Fix
`#[NoCSRFRequired]` an `pdfRange()`. Unbedenklich: lesender GET-Download (idempotent), Standardmuster für `window.open`-Downloads.

## Prävention (Maschine statt Merksatz)
Reflection-Test erzwingt `#[NoCSRFRequired]` für **jede** `ReportController`-Methode mit Rückgabetyp `DataDownloadResponse` — hätte genau diesen Bug gefangen. **Mutationsverifiziert** (Attribut entfernt → Test rot).

## Verifiziert
- **413/413** Unit-Tests grün (+1)
- Dev-Instanz: Direktnavigation ohne Token an `pdf-range` liefert jetzt `200 application/pdf` (vorher CSRF-Fehler), identisch zum Monatsbericht

Fixes #620