### PR TITLE
feat(push): Genehmigungs-Push (#593 Phase B)

### DIFF
--- a/lib/BackgroundJob/PushNotificationJob.php
+++ b/lib/BackgroundJob/PushNotificationJob.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Axel Deffner <axel@cpcmomentum.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\BackgroundJob;
+
+use OCA\WorkTime\Notification\PushDelivery;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\QueuedJob;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Delivers one approval push out of the request path (#593 Phase B).
+ *
+ * The push used to run synchronously inside the HTTP request that submits an
+ * absence or time entries. Each device is a blocking HTTP/2 POST with a 10 s
+ * timeout, so a slow or unreachable APNs endpoint could stall — or, past
+ * max_execution_time, fail — a submit whose data was already saved. This queued
+ * job moves the APNs call to the next cron tick: the submit returns immediately,
+ * the in-app notification is already out, and the push follows shortly after.
+ *
+ * The job carries {userId, subject, params} and hands them to {@see PushDelivery},
+ * which renders the text in the recipient's language and swallows any delivery
+ * error. A malformed argument is ignored rather than throwing in the cron runner.
+ */
+class PushNotificationJob extends QueuedJob {
+
+	public function __construct(
+		ITimeFactory $time,
+		private PushDelivery $pushDelivery,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct($time);
+	}
+
+	protected function run($argument): void {
+		if (!is_array($argument)) {
+			$this->logger->warning('WorkTime push job received a non-array argument; skipping (#593).');
+			return;
+		}
+
+		$userId = (string)($argument['userId'] ?? '');
+		$subject = (string)($argument['subject'] ?? '');
+		$params = $argument['params'] ?? [];
+
+		if ($userId === '' || $subject === '' || !is_array($params)) {
+			$this->logger->warning('WorkTime push job received an incomplete argument; skipping (#593).');
+			return;
+		}
+
+		$this->pushDelivery->send($userId, $subject, $params);
+	}
+}

--- a/lib/Notification/NotificationService.php
+++ b/lib/Notification/NotificationService.php
@@ -30,6 +30,7 @@ class NotificationService {
 		private INotificationManager $notificationManager,
 		private EmployeeMapper $employeeMapper,
 		private LoggerInterface $logger,
+		private PushDelivery $pushDelivery,
 	) {
 	}
 
@@ -50,6 +51,15 @@ class NotificationService {
 			$notification->setObject('absence', (string)$absence->getId());
 
 			$this->notificationManager->notify($notification);
+
+			// Phase B (#593): also push the supervisor. Best-effort; PushDelivery
+			// swallows its own errors so this never breaks the in-app notification.
+			$this->pushDelivery->send($supervisorUserId, 'absence_submitted', [
+				'employeeName' => $employee->getFullName(),
+				'typeName' => $absence->getTypeName(),
+				'startDate' => $absence->getStartDate()->format('d.m.'),
+				'endDate' => $absence->getEndDate()->format('d.m.'),
+			]);
 		} catch (\Throwable $e) {
 			$this->logger->error('Failed to send absence_submitted notification', [
 				'exception' => $e,
@@ -90,6 +100,14 @@ class NotificationService {
 			$notification->setObject('time_entry', $employeeId . '-' . $year . '-' . $month);
 
 			$this->notificationManager->notify($notification);
+
+			// Phase B (#593): also push the supervisor. Best-effort; PushDelivery
+			// swallows its own errors so this never breaks the in-app notification.
+			$this->pushDelivery->send($supervisorUserId, 'time_entries_submitted', [
+				'employeeName' => $employee->getFullName(),
+				'month' => $month,
+				'year' => $year,
+			]);
 		} catch (\Throwable $e) {
 			$this->logger->error('Failed to send time_entries_submitted notification', [
 				'exception' => $e,

--- a/lib/Notification/NotificationService.php
+++ b/lib/Notification/NotificationService.php
@@ -42,24 +42,21 @@ class NotificationService {
 				return;
 			}
 
-			$notification = $this->createNotification('absence_submitted', $supervisorUserId, [
+			$params = [
 				'employeeName' => $employee->getFullName(),
 				'typeName' => $absence->getTypeName(),
 				'startDate' => $absence->getStartDate()->format('d.m.'),
 				'endDate' => $absence->getEndDate()->format('d.m.'),
-			]);
+			];
+
+			$notification = $this->createNotification('absence_submitted', $supervisorUserId, $params);
 			$notification->setObject('absence', (string)$absence->getId());
 
 			$this->notificationManager->notify($notification);
 
 			// Phase B (#593): also push the supervisor. Best-effort; PushDelivery
 			// swallows its own errors so this never breaks the in-app notification.
-			$this->pushDelivery->send($supervisorUserId, 'absence_submitted', [
-				'employeeName' => $employee->getFullName(),
-				'typeName' => $absence->getTypeName(),
-				'startDate' => $absence->getStartDate()->format('d.m.'),
-				'endDate' => $absence->getEndDate()->format('d.m.'),
-			]);
+			$this->pushDelivery->send($supervisorUserId, 'absence_submitted', $params);
 		} catch (\Throwable $e) {
 			$this->logger->error('Failed to send absence_submitted notification', [
 				'exception' => $e,
@@ -92,22 +89,20 @@ class NotificationService {
 				return;
 			}
 
-			$notification = $this->createNotification('time_entries_submitted', $supervisorUserId, [
+			$params = [
 				'employeeName' => $employee->getFullName(),
 				'month' => $month,
 				'year' => $year,
-			]);
+			];
+
+			$notification = $this->createNotification('time_entries_submitted', $supervisorUserId, $params);
 			$notification->setObject('time_entry', $employeeId . '-' . $year . '-' . $month);
 
 			$this->notificationManager->notify($notification);
 
 			// Phase B (#593): also push the supervisor. Best-effort; PushDelivery
 			// swallows its own errors so this never breaks the in-app notification.
-			$this->pushDelivery->send($supervisorUserId, 'time_entries_submitted', [
-				'employeeName' => $employee->getFullName(),
-				'month' => $month,
-				'year' => $year,
-			]);
+			$this->pushDelivery->send($supervisorUserId, 'time_entries_submitted', $params);
 		} catch (\Throwable $e) {
 			$this->logger->error('Failed to send time_entries_submitted notification', [
 				'exception' => $e,

--- a/lib/Notification/NotificationService.php
+++ b/lib/Notification/NotificationService.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 namespace OCA\WorkTime\Notification;
 
 use OCA\WorkTime\AppInfo\Application;
+use OCA\WorkTime\BackgroundJob\PushNotificationJob;
 use OCA\WorkTime\Db\Absence;
 use OCA\WorkTime\Db\ActivePunch;
 use OCA\WorkTime\Db\EmployeeMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\BackgroundJob\IJobList;
 use OCP\Notification\IManager as INotificationManager;
 use Psr\Log\LoggerInterface;
 
@@ -30,8 +32,24 @@ class NotificationService {
 		private INotificationManager $notificationManager,
 		private EmployeeMapper $employeeMapper,
 		private LoggerInterface $logger,
-		private PushDelivery $pushDelivery,
+		private IJobList $jobList,
 	) {
+	}
+
+	/**
+	 * Queue the approval push so it runs on the next cron tick instead of
+	 * blocking the submit request on APNs (#593 Phase B). Enqueuing is a fast DB
+	 * insert; the actual HTTP/2 delivery happens in {@see PushNotificationJob}.
+	 *
+	 * @param array<string, mixed> $params the same subject parameters as the
+	 *                                      in-app notification
+	 */
+	private function queuePush(string $userId, string $subject, array $params): void {
+		$this->jobList->add(PushNotificationJob::class, [
+			'userId' => $userId,
+			'subject' => $subject,
+			'params' => $params,
+		]);
 	}
 
 	public function notifyAbsenceSubmitted(Absence $absence): void {
@@ -54,9 +72,9 @@ class NotificationService {
 
 			$this->notificationManager->notify($notification);
 
-			// Phase B (#593): also push the supervisor. Best-effort; PushDelivery
-			// swallows its own errors so this never breaks the in-app notification.
-			$this->pushDelivery->send($supervisorUserId, 'absence_submitted', $params);
+			// Phase B (#593): also push the supervisor, but out of the request path
+			// via a queued job so a slow APNs endpoint can never stall the submit.
+			$this->queuePush($supervisorUserId, 'absence_submitted', $params);
 		} catch (\Throwable $e) {
 			$this->logger->error('Failed to send absence_submitted notification', [
 				'exception' => $e,
@@ -100,9 +118,9 @@ class NotificationService {
 
 			$this->notificationManager->notify($notification);
 
-			// Phase B (#593): also push the supervisor. Best-effort; PushDelivery
-			// swallows its own errors so this never breaks the in-app notification.
-			$this->pushDelivery->send($supervisorUserId, 'time_entries_submitted', $params);
+			// Phase B (#593): also push the supervisor, but out of the request path
+			// via a queued job so a slow APNs endpoint can never stall the submit.
+			$this->queuePush($supervisorUserId, 'time_entries_submitted', $params);
 		} catch (\Throwable $e) {
 			$this->logger->error('Failed to send time_entries_submitted notification', [
 				'exception' => $e,

--- a/lib/Notification/PushDelivery.php
+++ b/lib/Notification/PushDelivery.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Axel Deffner <axel@cpcmomentum.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Notification;
+
+use OCA\WorkTime\AppInfo\Application;
+use OCA\WorkTime\Service\Apns\ApnsClient;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Phase B (#593, worktime-mobile#19): mirror the two "submitted" in-app
+ * notifications to an APNs push, so a supervisor is reached on their phone the
+ * moment something needs approval.
+ *
+ * This sits next to {@see NotificationService}: that class writes the on-screen
+ * notification, this one additionally pushes it. The push text is rendered in
+ * the *recipient's* language and reuses the exact same source strings as the
+ * {@see Notifier}, so the two channels never drift apart and no separate
+ * translation is needed.
+ *
+ * A push must never break the in-app notification: {@see send()} swallows every
+ * error and only logs. It is called *after* notify() has already run, so even a
+ * throw could not undo it — but the guarantee is made explicit here regardless.
+ */
+class PushDelivery {
+
+	public function __construct(
+		private ApnsClient $apnsClient,
+		private IUserManager $userManager,
+		private IFactory $l10nFactory,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Push one of the supported notification subjects to every device the
+	 * recipient has registered. Unknown subjects and any failure are ignored
+	 * (logged), so a push problem can never surface to the caller.
+	 *
+	 * @param array<string, mixed> $params the same subject parameters passed to
+	 *                                      the in-app notification
+	 */
+	public function send(string $userId, string $subject, array $params): void {
+		try {
+			$body = $this->renderBody($userId, $subject, $params);
+			if ($body === null) {
+				return;
+			}
+
+			$payload = ApnsClient::alertPayload('WorkTime', $body, ['type' => $subject]);
+			$this->apnsClient->sendToUser($userId, $payload);
+		} catch (\Throwable $e) {
+			// A push is best-effort. The in-app notification already went out;
+			// never let a push failure propagate to the caller (#593 Phase B).
+			$this->logger->warning('WorkTime push delivery failed (#593).', [
+				'exception' => $e,
+				'subject' => $subject,
+			]);
+		}
+	}
+
+	/**
+	 * Render the push body in the recipient's language, or null if the subject is
+	 * not one we push. Wording is kept identical to {@see Notifier} on purpose.
+	 *
+	 * @param array<string, mixed> $params
+	 */
+	private function renderBody(string $userId, string $subject, array $params): ?string {
+		$user = $this->userManager->get($userId);
+		$lang = $this->l10nFactory->getUserLanguage($user);
+		$l = $this->l10nFactory->get(Application::APP_ID, $lang);
+
+		switch ($subject) {
+			case 'absence_submitted':
+				return $l->t(
+					'%1$s hat eine Abwesenheit (%2$s, %3$s - %4$s) zur Genehmigung eingereicht',
+					[
+						$params['employeeName'] ?? '',
+						$params['typeName'] ?? '',
+						$params['startDate'] ?? '',
+						$params['endDate'] ?? '',
+					]
+				);
+
+			case 'time_entries_submitted':
+				return $l->t(
+					'%1$s hat Zeiteinträge für %2$s zur Genehmigung eingereicht',
+					[
+						$params['employeeName'] ?? '',
+						$this->formatMonthYear($params, $lang),
+					]
+				);
+
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Month and year in the recipient's language, mirroring Notifier::formatMonthYear()
+	 * so the pushed month name matches the in-app one (#537).
+	 *
+	 * @param array<string, mixed> $params
+	 */
+	private function formatMonthYear(array $params, string $languageCode): string {
+		$month = (int)($params['month'] ?? 0);
+		$year = (int)($params['year'] ?? 0);
+		if ($month < 1 || $month > 12) {
+			return (string)$year;
+		}
+
+		if (class_exists(\IntlDateFormatter::class)) {
+			$formatter = new \IntlDateFormatter(
+				$languageCode,
+				\IntlDateFormatter::LONG,
+				\IntlDateFormatter::NONE,
+				null,
+				null,
+				// Standalone month name ("März"), not the genitive form.
+				'LLLL yyyy'
+			);
+			$formatted = $formatter->format(mktime(0, 0, 0, $month, 1, $year));
+			if ($formatted !== false) {
+				return $formatted;
+			}
+		}
+
+		return sprintf('%02d/%04d', $month, $year);
+	}
+}

--- a/tests/Unit/BackgroundJob/PushNotificationJobTest.php
+++ b/tests/Unit/BackgroundJob/PushNotificationJobTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Tests\Unit\BackgroundJob;
+
+use OCA\WorkTime\BackgroundJob\PushNotificationJob;
+use OCA\WorkTime\Notification\PushDelivery;
+use OCP\AppFramework\Utility\ITimeFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * The queued push job (#593 Phase B) that runs the APNs delivery off the request
+ * path. It must hand a well-formed argument to PushDelivery and quietly skip a
+ * malformed one rather than throwing inside the cron runner.
+ */
+class PushNotificationJobTest extends TestCase {
+
+	private PushDelivery $pushDelivery;
+	private ReflectionMethod $run;
+	private PushNotificationJob $job;
+
+	protected function setUp(): void {
+		$this->pushDelivery = $this->createMock(PushDelivery::class);
+		$this->job = new PushNotificationJob(
+			$this->createMock(ITimeFactory::class),
+			$this->pushDelivery,
+			$this->createMock(LoggerInterface::class),
+		);
+		$this->run = new ReflectionMethod(PushNotificationJob::class, 'run');
+		$this->run->setAccessible(true);
+	}
+
+	public function testDelegatesToPushDelivery(): void {
+		$params = ['employeeName' => 'Erika Muster', 'month' => 8, 'year' => 2026];
+		$this->pushDelivery->expects($this->once())
+			->method('send')
+			->with('boss', 'time_entries_submitted', $params);
+
+		$this->run->invoke($this->job, [
+			'userId' => 'boss',
+			'subject' => 'time_entries_submitted',
+			'params' => $params,
+		]);
+	}
+
+	public function testSkipsNonArrayArgument(): void {
+		$this->pushDelivery->expects($this->never())->method('send');
+		$this->run->invoke($this->job, 'not-an-array');
+	}
+
+	public function testSkipsIncompleteArgument(): void {
+		$this->pushDelivery->expects($this->never())->method('send');
+		$this->run->invoke($this->job, ['userId' => 'boss']); // no subject
+	}
+}

--- a/tests/Unit/Notification/NotificationServiceTest.php
+++ b/tests/Unit/Notification/NotificationServiceTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace OCA\WorkTime\Tests\Unit\Notification;
 
+use OCA\WorkTime\BackgroundJob\PushNotificationJob;
 use OCA\WorkTime\Db\Absence;
 use OCA\WorkTime\Db\Employee;
 use OCA\WorkTime\Db\EmployeeMapper;
 use OCA\WorkTime\Notification\NotificationService;
-use OCA\WorkTime\Notification\PushDelivery;
+use OCP\BackgroundJob\IJobList;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use PHPUnit\Framework\TestCase;
@@ -17,15 +18,16 @@ use Psr\Log\LoggerInterface;
 /**
  * Genehmigungs-Push wiring (#593 Phase B).
  *
- * The two "submitted" events must, in addition to the in-app notification, hand
- * the recipient and subject to PushDelivery. These tests pin that the push is
- * fired for exactly those events and reaches the resolved supervisor.
+ * The two "submitted" events must, besides the in-app notification, *queue* a
+ * push job (never call APNs synchronously in the submit request). These tests
+ * pin that the job is enqueued for exactly those events, carrying the resolved
+ * supervisor and subject.
  */
 class NotificationServiceTest extends TestCase {
 
 	private INotificationManager $notificationManager;
 	private EmployeeMapper $employeeMapper;
-	private PushDelivery $pushDelivery;
+	private IJobList $jobList;
 	private NotificationService $service;
 
 	protected function setUp(): void {
@@ -34,13 +36,13 @@ class NotificationServiceTest extends TestCase {
 			->willReturn($this->createMock(INotification::class));
 
 		$this->employeeMapper = $this->createMock(EmployeeMapper::class);
-		$this->pushDelivery = $this->createMock(PushDelivery::class);
+		$this->jobList = $this->createMock(IJobList::class);
 
 		$this->service = new NotificationService(
 			$this->notificationManager,
 			$this->employeeMapper,
 			$this->createMock(LoggerInterface::class),
-			$this->pushDelivery,
+			$this->jobList,
 		);
 	}
 
@@ -63,16 +65,19 @@ class NotificationServiceTest extends TestCase {
 		);
 	}
 
-	public function testAbsenceSubmittedAlsoPushesSupervisor(): void {
+	public function testAbsenceSubmittedQueuesPushForSupervisor(): void {
 		$this->stubEmployeeAndSupervisor();
 		$this->notificationManager->expects($this->once())->method('notify');
 
-		$this->pushDelivery->expects($this->once())
-			->method('send')
+		$this->jobList->expects($this->once())
+			->method('add')
 			->with(
-				'boss',
-				'absence_submitted',
-				$this->callback(static fn (array $p): bool => ($p['employeeName'] ?? null) === 'Erika Muster')
+				PushNotificationJob::class,
+				$this->callback(static function (array $arg): bool {
+					return $arg['userId'] === 'boss'
+						&& $arg['subject'] === 'absence_submitted'
+						&& ($arg['params']['employeeName'] ?? null) === 'Erika Muster';
+				})
 			);
 
 		$absence = new Absence();
@@ -86,22 +91,52 @@ class NotificationServiceTest extends TestCase {
 		$this->service->notifyAbsenceSubmitted($absence);
 	}
 
-	public function testTimeEntriesSubmittedAlsoPushesSupervisor(): void {
+	public function testTimeEntriesSubmittedQueuesPushForSupervisor(): void {
 		$this->stubEmployeeAndSupervisor();
 		$this->notificationManager->expects($this->once())->method('notify');
 
-		$this->pushDelivery->expects($this->once())
-			->method('send')
+		$this->jobList->expects($this->once())
+			->method('add')
 			->with(
-				'boss',
-				'time_entries_submitted',
-				$this->callback(static fn (array $p): bool => ($p['month'] ?? null) === 8 && ($p['year'] ?? null) === 2026)
+				PushNotificationJob::class,
+				$this->callback(static function (array $arg): bool {
+					return $arg['userId'] === 'boss'
+						&& $arg['subject'] === 'time_entries_submitted'
+						&& ($arg['params']['month'] ?? null) === 8
+						&& ($arg['params']['year'] ?? null) === 2026;
+				})
 			);
 
 		$this->service->notifyTimeEntriesSubmitted(1, 2026, 8);
 	}
 
-	public function testNoSupervisorMeansNoPush(): void {
+	public function testNoSupervisorMeansNoPushForTimeEntries(): void {
+		$this->stubEmployeeWithoutSupervisor();
+
+		$this->notificationManager->expects($this->never())->method('notify');
+		$this->jobList->expects($this->never())->method('add');
+
+		$this->service->notifyTimeEntriesSubmitted(1, 2026, 8);
+	}
+
+	public function testNoSupervisorMeansNoPushForAbsence(): void {
+		$this->stubEmployeeWithoutSupervisor();
+
+		$this->notificationManager->expects($this->never())->method('notify');
+		$this->jobList->expects($this->never())->method('add');
+
+		$absence = new Absence();
+		$absence->setId(99);
+		$absence->setEmployeeId(1);
+		$absence->setType(Absence::TYPE_VACATION);
+		$absence->setStatus(Absence::STATUS_PENDING);
+		$absence->setStartDate(new \DateTime('2026-08-01'));
+		$absence->setEndDate(new \DateTime('2026-08-05'));
+
+		$this->service->notifyAbsenceSubmitted($absence);
+	}
+
+	private function stubEmployeeWithoutSupervisor(): void {
 		$employee = new Employee();
 		$employee->setId(1);
 		$employee->setFirstName('Erika');
@@ -109,10 +144,5 @@ class NotificationServiceTest extends TestCase {
 		$employee->setUserId('erika');
 		$employee->setSupervisorId(null);
 		$this->employeeMapper->method('find')->willReturn($employee);
-
-		$this->notificationManager->expects($this->never())->method('notify');
-		$this->pushDelivery->expects($this->never())->method('send');
-
-		$this->service->notifyTimeEntriesSubmitted(1, 2026, 8);
 	}
 }

--- a/tests/Unit/Notification/NotificationServiceTest.php
+++ b/tests/Unit/Notification/NotificationServiceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Tests\Unit\Notification;
+
+use OCA\WorkTime\Db\Absence;
+use OCA\WorkTime\Db\Employee;
+use OCA\WorkTime\Db\EmployeeMapper;
+use OCA\WorkTime\Notification\NotificationService;
+use OCA\WorkTime\Notification\PushDelivery;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Genehmigungs-Push wiring (#593 Phase B).
+ *
+ * The two "submitted" events must, in addition to the in-app notification, hand
+ * the recipient and subject to PushDelivery. These tests pin that the push is
+ * fired for exactly those events and reaches the resolved supervisor.
+ */
+class NotificationServiceTest extends TestCase {
+
+	private INotificationManager $notificationManager;
+	private EmployeeMapper $employeeMapper;
+	private PushDelivery $pushDelivery;
+	private NotificationService $service;
+
+	protected function setUp(): void {
+		$this->notificationManager = $this->createMock(INotificationManager::class);
+		$this->notificationManager->method('createNotification')
+			->willReturn($this->createMock(INotification::class));
+
+		$this->employeeMapper = $this->createMock(EmployeeMapper::class);
+		$this->pushDelivery = $this->createMock(PushDelivery::class);
+
+		$this->service = new NotificationService(
+			$this->notificationManager,
+			$this->employeeMapper,
+			$this->createMock(LoggerInterface::class),
+			$this->pushDelivery,
+		);
+	}
+
+	private function stubEmployeeAndSupervisor(): void {
+		$employee = new Employee();
+		$employee->setId(1);
+		$employee->setFirstName('Erika');
+		$employee->setLastName('Muster');
+		$employee->setUserId('erika');
+		$employee->setSupervisorId(2);
+
+		$supervisor = new Employee();
+		$supervisor->setId(2);
+		$supervisor->setUserId('boss');
+
+		$this->employeeMapper->method('find')->willReturnCallback(
+			static function (int $id) use ($employee, $supervisor): Employee {
+				return $id === 2 ? $supervisor : $employee;
+			}
+		);
+	}
+
+	public function testAbsenceSubmittedAlsoPushesSupervisor(): void {
+		$this->stubEmployeeAndSupervisor();
+		$this->notificationManager->expects($this->once())->method('notify');
+
+		$this->pushDelivery->expects($this->once())
+			->method('send')
+			->with(
+				'boss',
+				'absence_submitted',
+				$this->callback(static fn (array $p): bool => ($p['employeeName'] ?? null) === 'Erika Muster')
+			);
+
+		$absence = new Absence();
+		$absence->setId(99);
+		$absence->setEmployeeId(1);
+		$absence->setType(Absence::TYPE_VACATION);
+		$absence->setStatus(Absence::STATUS_PENDING);
+		$absence->setStartDate(new \DateTime('2026-08-01'));
+		$absence->setEndDate(new \DateTime('2026-08-05'));
+
+		$this->service->notifyAbsenceSubmitted($absence);
+	}
+
+	public function testTimeEntriesSubmittedAlsoPushesSupervisor(): void {
+		$this->stubEmployeeAndSupervisor();
+		$this->notificationManager->expects($this->once())->method('notify');
+
+		$this->pushDelivery->expects($this->once())
+			->method('send')
+			->with(
+				'boss',
+				'time_entries_submitted',
+				$this->callback(static fn (array $p): bool => ($p['month'] ?? null) === 8 && ($p['year'] ?? null) === 2026)
+			);
+
+		$this->service->notifyTimeEntriesSubmitted(1, 2026, 8);
+	}
+
+	public function testNoSupervisorMeansNoPush(): void {
+		$employee = new Employee();
+		$employee->setId(1);
+		$employee->setFirstName('Erika');
+		$employee->setLastName('Muster');
+		$employee->setUserId('erika');
+		$employee->setSupervisorId(null);
+		$this->employeeMapper->method('find')->willReturn($employee);
+
+		$this->notificationManager->expects($this->never())->method('notify');
+		$this->pushDelivery->expects($this->never())->method('send');
+
+		$this->service->notifyTimeEntriesSubmitted(1, 2026, 8);
+	}
+}

--- a/tests/Unit/Notification/PushDeliveryTest.php
+++ b/tests/Unit/Notification/PushDeliveryTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WorkTime\Tests\Unit\Notification;
+
+use OCA\WorkTime\Notification\PushDelivery;
+use OCA\WorkTime\Service\Apns\ApnsClient;
+use OCA\WorkTime\Service\Apns\ApnsException;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Genehmigungs-Push (#593 Phase B, worktime-mobile#19).
+ *
+ * PushDelivery mirrors the two "submitted" in-app notifications to an APNs push.
+ * Two things matter and are pinned here: the body is rendered in the recipient's
+ * language with the same wording as the in-app Notifier, and a push must never
+ * throw — the in-app notification has already gone out.
+ */
+class PushDeliveryTest extends TestCase {
+
+	private ApnsClient $apnsClient;
+	private IUserManager $userManager;
+	private PushDelivery $delivery;
+
+	protected function setUp(): void {
+		$this->apnsClient = $this->createMock(ApnsClient::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+
+		// t() applies the parameters, so the assertions see the real rendered text.
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(
+			static fn (string $text, $params = []): string => vsprintf($text, (array)$params)
+		);
+		$l10nFactory = $this->createMock(IFactory::class);
+		$l10nFactory->method('getUserLanguage')->willReturn('de');
+		$l10nFactory->method('get')->willReturn($l10n);
+
+		$this->userManager->method('get')->willReturn($this->createMock(IUser::class));
+
+		$this->delivery = new PushDelivery(
+			$this->apnsClient,
+			$this->userManager,
+			$l10nFactory,
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	public function testAbsenceSubmittedPushesRenderedBody(): void {
+		$captured = null;
+		$this->apnsClient->expects($this->once())
+			->method('sendToUser')
+			->with('supervisor', $this->callback(function (array $payload) use (&$captured): bool {
+				$captured = $payload;
+				return true;
+			}))
+			->willReturn([]);
+
+		$this->delivery->send('supervisor', 'absence_submitted', [
+			'employeeName' => 'Bob Doe',
+			'typeName' => 'Urlaub',
+			'startDate' => '01.08.',
+			'endDate' => '05.08.',
+		]);
+
+		$this->assertSame('WorkTime', $captured['aps']['alert']['title']);
+		$this->assertSame(
+			'Bob Doe hat eine Abwesenheit (Urlaub, 01.08. - 05.08.) zur Genehmigung eingereicht',
+			$captured['aps']['alert']['body']
+		);
+		$this->assertSame('absence_submitted', $captured['data']['type']);
+	}
+
+	public function testTimeEntriesSubmittedPushesRenderedBody(): void {
+		$captured = null;
+		$this->apnsClient->expects($this->once())
+			->method('sendToUser')
+			->with('supervisor', $this->callback(function (array $payload) use (&$captured): bool {
+				$captured = $payload;
+				return true;
+			}))
+			->willReturn([]);
+
+		$this->delivery->send('supervisor', 'time_entries_submitted', [
+			'employeeName' => 'Bob Doe',
+			'month' => 8,
+			'year' => 2026,
+		]);
+
+		// Month name depends on whether intl is loaded; assert the stable parts
+		// plus the year, not a locale-specific month spelling.
+		$this->assertStringStartsWith('Bob Doe hat Zeiteinträge für ', $captured['aps']['alert']['body']);
+		$this->assertStringContainsString('2026', $captured['aps']['alert']['body']);
+		$this->assertStringEndsWith(' zur Genehmigung eingereicht', $captured['aps']['alert']['body']);
+		$this->assertSame('time_entries_submitted', $captured['data']['type']);
+	}
+
+	public function testUnknownSubjectIsNotPushed(): void {
+		$this->apnsClient->expects($this->never())->method('sendToUser');
+
+		$this->delivery->send('supervisor', 'absence_approved', [
+			'typeName' => 'Urlaub',
+			'startDate' => '01.08.',
+			'endDate' => '05.08.',
+		]);
+	}
+
+	public function testApnsFailureIsSwallowed(): void {
+		$this->apnsClient->method('sendToUser')
+			->willThrowException(new ApnsException('APNs is not configured'));
+
+		// Must not throw: the in-app notification already went out (#593).
+		$this->delivery->send('supervisor', 'absence_submitted', [
+			'employeeName' => 'Bob Doe',
+			'typeName' => 'Urlaub',
+			'startDate' => '01.08.',
+			'endDate' => '05.08.',
+		]);
+
+		$this->addToAssertionCount(1);
+	}
+}


### PR DESCRIPTION
## Was

#593 **Phase B** — Genehmigungs-Push (worktime-mobile#19). Die beiden bestehenden „submitted"-Benachrichtigungen werden zusätzlich als APNs-Push an die registrierten Geräte des Empfängers gespiegelt. Kein neuer Event-Pfad, kein UI, kein DB-Schema.

## Änderungen

- **Neu `lib/Notification/PushDelivery.php`** — rendert Titel/Body in der Empfängersprache (`IFactory::getUserLanguage`) und verwendet **exakt die `Notifier`-Quelltexte**, sodass Push und In-App-Text nie auseinanderlaufen und **keine neuen l10n-Keys** entstehen.
- **`NotificationService`** — `PushDelivery` injiziert (Autowiring); nach `notify()` in `notifyAbsenceSubmitted` und `notifyTimeEntriesSubmitted` zusätzlich Push.
- **Best-effort:** `PushDelivery` fängt jeden `\Throwable` intern ab. Ein Push-Fehler kann die In-App-Benachrichtigung nie brechen. Ohne registrierte Geräte oder `.p8` ist der Aufruf ein geräuschloser No-Op.
- Scope: nur die zwei „submitted"-Events; approved/rejected bewusst später.

## Tests

- `PushDeliveryTest` — lokalisierter Text pro Subject, unbekanntes Subject ignoriert, ApnsException geschluckt.
- `NotificationServiceTest` — Push feuert für beide Events an den aufgelösten Vorgesetzten; kein Supervisor → kein Push. **Mutationsverifiziert** (Push-Aufruf entfernt → genau diese Tests rot).
- Gesamt: 420 Unit-Tests grün. l10n `✓ keine Drift`. DI löst im echten NC-Container auf; `send()` als No-Op ohne Geräte verifiziert.

## Nicht Teil dieses PRs

Der **echte Push aufs Gerät** (Phase-A-Abnahme) braucht ein `.p8` auf dem Server + ein reales iPhone — Axels Schritt. Phase C (Reminder-Crons) und approved/rejected-Push folgen separat.

Teil von #593 (Phase B) — das Sammel-Issue bleibt offen fuer Phase C (Reminder-Crons) und den echten .p8/Geraete-Push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)