### PR TITLE
feat(push): Entscheidungen + Stoppuhr-Reminder pushen (#593)

### DIFF
--- a/lib/Notification/NotificationService.php
+++ b/lib/Notification/NotificationService.php
@@ -190,14 +190,19 @@ class NotificationService {
 		try {
 			$employee = $this->employeeMapper->find($absence->getEmployeeId());
 
-			$notification = $this->createNotification($subject, $employee->getUserId(), [
+			$params = [
 				'typeName' => $absence->getTypeName(),
 				'startDate' => $absence->getStartDate()->format('d.m.'),
 				'endDate' => $absence->getEndDate()->format('d.m.'),
-			]);
+			];
+
+			$notification = $this->createNotification($subject, $employee->getUserId(), $params);
 			$notification->setObject('absence', (string)$absence->getId());
 
 			$this->notificationManager->notify($notification);
+
+			// Phase B/C (#593): mirror the decision to the employee's phone.
+			$this->queuePush($employee->getUserId(), $subject, $params);
 		} catch (\Throwable $e) {
 			$this->logger->error('Failed to send ' . $subject . ' notification', [
 				'exception' => $e,
@@ -210,14 +215,19 @@ class NotificationService {
 		try {
 			$employee = $this->employeeMapper->find($employeeId);
 
-			$notification = $this->createNotification($subject, $employee->getUserId(), [
+			$params = [
 				'month' => $month,
 				'year' => $year,
 				'reason' => $reason,
-			]);
+			];
+
+			$notification = $this->createNotification($subject, $employee->getUserId(), $params);
 			$notification->setObject('time_entry', $employeeId . '-' . $year . '-' . $month);
 
 			$this->notificationManager->notify($notification);
+
+			// Phase B/C (#593): mirror the decision to the employee's phone.
+			$this->queuePush($employee->getUserId(), $subject, $params);
 		} catch (\Throwable $e) {
 			$this->logger->error('Failed to send ' . $subject . ' notification', [
 				'exception' => $e,
@@ -260,6 +270,10 @@ class NotificationService {
 		$notification->setSubject('punch_pause_reminder', ['maxPause' => $maxPauseMinutes]);
 
 		$this->notificationManager->notify($notification);
+
+		// Phase C (#593): the reminder job runs server-side, so also push it to
+		// the employee's phone.
+		$this->queuePush($userId, 'punch_pause_reminder', ['maxPause' => $maxPauseMinutes]);
 	}
 
 	/**
@@ -280,6 +294,10 @@ class NotificationService {
 		$notification->setSubject('punch_out_reminder', ['hours' => $thresholdHours]);
 
 		$this->notificationManager->notify($notification);
+
+		// Phase C (#593): the reminder job runs server-side, so also push it to
+		// the employee's phone.
+		$this->queuePush($userId, 'punch_out_reminder', ['hours' => $thresholdHours]);
 	}
 
 	/**

--- a/lib/Notification/NotificationService.php
+++ b/lib/Notification/NotificationService.php
@@ -45,6 +45,13 @@ class NotificationService {
 	 *                                      in-app notification
 	 */
 	private function queuePush(string $userId, string $subject, array $params): void {
+		// Only enqueue when the subject actually has a push rendering, so
+		// in-app-only subjects (e.g. time_entries_reopened) don't insert a job
+		// that would no-op in PushDelivery.
+		if (!PushDelivery::supports($subject)) {
+			return;
+		}
+
 		$this->jobList->add(PushNotificationJob::class, [
 			'userId' => $userId,
 			'subject' => $subject,

--- a/lib/Notification/PushDelivery.php
+++ b/lib/Notification/PushDelivery.php
@@ -16,9 +16,10 @@ use OCP\L10N\IFactory;
 use Psr\Log\LoggerInterface;
 
 /**
- * Phase B (#593, worktime-mobile#19): mirror the two "submitted" in-app
- * notifications to an APNs push, so a supervisor is reached on their phone the
- * moment something needs approval.
+ * Phase B/C (#593, worktime-mobile#19): mirror the relevant in-app
+ * notifications to an APNs push, so the recipient is reached on their phone —
+ * a supervisor when something needs approval (submitted), an employee when a
+ * decision is made (approved/rejected) or a stopwatch reminder fires (#588).
  *
  * This sits next to {@see NotificationService}: that class writes the on-screen
  * notification, this one additionally pushes it. The push text is rendered in
@@ -97,6 +98,50 @@ class PushDelivery {
 						$params['employeeName'] ?? '',
 						$this->formatMonthYear($params, $lang),
 					]
+				);
+
+			case 'absence_approved':
+				return $l->t(
+					'Deine Abwesenheit (%1$s, %2$s - %3$s) wurde genehmigt',
+					[
+						$params['typeName'] ?? '',
+						$params['startDate'] ?? '',
+						$params['endDate'] ?? '',
+					]
+				);
+
+			case 'absence_rejected':
+				return $l->t(
+					'Deine Abwesenheit (%1$s, %2$s - %3$s) wurde abgelehnt',
+					[
+						$params['typeName'] ?? '',
+						$params['startDate'] ?? '',
+						$params['endDate'] ?? '',
+					]
+				);
+
+			case 'time_entries_approved':
+				return $l->t(
+					'Deine Zeiteinträge für %s wurden genehmigt',
+					[$this->formatMonthYear($params, $lang)]
+				);
+
+			case 'time_entries_rejected':
+				return $l->t(
+					'Deine Zeiteinträge für %s wurden abgelehnt',
+					[$this->formatMonthYear($params, $lang)]
+				);
+
+			case 'punch_pause_reminder':
+				return $l->t(
+					'Bist du noch in der Pause? Sie läuft seit über %d Minuten.',
+					[(int)($params['maxPause'] ?? 60)]
+				);
+
+			case 'punch_out_reminder':
+				return $l->t(
+					'Du bist seit über %d Stunden eingestempelt. Nicht vergessen auszustempeln.',
+					[(int)($params['hours'] ?? 10)]
 				);
 
 			default:

--- a/lib/Notification/PushDelivery.php
+++ b/lib/Notification/PushDelivery.php
@@ -33,6 +33,32 @@ use Psr\Log\LoggerInterface;
  */
 class PushDelivery {
 
+	/**
+	 * The notification subjects that have a mobile push rendering below. This is
+	 * the single source of truth for "is this pushable": NotificationService asks
+	 * it before enqueuing a PushNotificationJob, so subjects that only exist in
+	 * app (e.g. archive_failed, time_entries_reopened) never queue a job that
+	 * would no-op. Keep in sync with the cases in {@see renderBody()}.
+	 */
+	public const PUSHABLE_SUBJECTS = [
+		'absence_submitted',
+		'time_entries_submitted',
+		'absence_approved',
+		'absence_rejected',
+		'time_entries_approved',
+		'time_entries_rejected',
+		'punch_pause_reminder',
+		'punch_out_reminder',
+	];
+
+	/**
+	 * Whether a subject has a mobile push rendering. Used to avoid enqueuing a
+	 * job for an in-app-only subject.
+	 */
+	public static function supports(string $subject): bool {
+		return in_array($subject, self::PUSHABLE_SUBJECTS, true);
+	}
+
 	public function __construct(
 		private ApnsClient $apnsClient,
 		private IUserManager $userManager,

--- a/tests/Unit/Notification/NotificationServiceTest.php
+++ b/tests/Unit/Notification/NotificationServiceTest.php
@@ -17,12 +17,13 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * Genehmigungs-Push wiring (#593 Phase B).
+ * Genehmigungs-Push wiring (#593 Phase B/C).
  *
- * The two "submitted" events must, besides the in-app notification, *queue* a
- * push job (never call APNs synchronously in the submit request). These tests
- * pin that the job is enqueued for exactly those events, carrying the resolved
- * supervisor and subject.
+ * Besides the in-app notification, the "submitted", "approved"/"rejected" and
+ * stopwatch reminder events must *queue* a push job (never call APNs
+ * synchronously). These tests pin that the job is enqueued for exactly those
+ * events, carrying the resolved recipient and subject — and that subjects with
+ * no push rendering (e.g. reopened) queue nothing.
  */
 class NotificationServiceTest extends TestCase {
 

--- a/tests/Unit/Notification/NotificationServiceTest.php
+++ b/tests/Unit/Notification/NotificationServiceTest.php
@@ -191,6 +191,20 @@ class NotificationServiceTest extends TestCase {
 		$this->service->notifyPunchPauseTooLong($punch, new \DateTime('2026-08-24 12:00:00'), 60);
 	}
 
+	public function testReopenedNotifiesInAppButQueuesNoPush(): void {
+		$employee = new Employee();
+		$employee->setId(1);
+		$employee->setUserId('erika');
+		$this->employeeMapper->method('find')->willReturn($employee);
+
+		// In-app notification is sent, but reopened has no push rendering, so no
+		// job is queued (avoids a no-op job insert).
+		$this->notificationManager->expects($this->once())->method('notify');
+		$this->jobList->expects($this->never())->method('add');
+
+		$this->service->notifyTimeEntriesReopened(1, 2026, 8, 'Bitte korrigieren');
+	}
+
 	private function stubEmployeeWithoutSupervisor(): void {
 		$employee = new Employee();
 		$employee->setId(1);

--- a/tests/Unit/Notification/NotificationServiceTest.php
+++ b/tests/Unit/Notification/NotificationServiceTest.php
@@ -6,6 +6,7 @@ namespace OCA\WorkTime\Tests\Unit\Notification;
 
 use OCA\WorkTime\BackgroundJob\PushNotificationJob;
 use OCA\WorkTime\Db\Absence;
+use OCA\WorkTime\Db\ActivePunch;
 use OCA\WorkTime\Db\Employee;
 use OCA\WorkTime\Db\EmployeeMapper;
 use OCA\WorkTime\Notification\NotificationService;
@@ -134,6 +135,60 @@ class NotificationServiceTest extends TestCase {
 		$absence->setEndDate(new \DateTime('2026-08-05'));
 
 		$this->service->notifyAbsenceSubmitted($absence);
+	}
+
+	public function testAbsenceApprovedQueuesPushForEmployee(): void {
+		$employee = new Employee();
+		$employee->setId(1);
+		$employee->setUserId('erika');
+		$this->employeeMapper->method('find')->willReturn($employee);
+		$this->notificationManager->expects($this->once())->method('notify');
+
+		$this->jobList->expects($this->once())
+			->method('add')
+			->with(
+				PushNotificationJob::class,
+				$this->callback(static function (array $arg): bool {
+					return $arg['userId'] === 'erika'
+						&& $arg['subject'] === 'absence_approved'
+						&& ($arg['params']['typeName'] ?? null) === 'Urlaub';
+				})
+			);
+
+		$absence = new Absence();
+		$absence->setId(99);
+		$absence->setEmployeeId(1);
+		$absence->setType(Absence::TYPE_VACATION);
+		$absence->setStatus(Absence::STATUS_APPROVED);
+		$absence->setStartDate(new \DateTime('2026-08-01'));
+		$absence->setEndDate(new \DateTime('2026-08-05'));
+
+		$this->service->notifyAbsenceApproved($absence);
+	}
+
+	public function testPunchPauseReminderQueuesPushForEmployee(): void {
+		$employee = new Employee();
+		$employee->setId(7);
+		$employee->setUserId('erika');
+		$this->employeeMapper->method('find')->willReturn($employee);
+		$this->notificationManager->expects($this->once())->method('notify');
+
+		$this->jobList->expects($this->once())
+			->method('add')
+			->with(
+				PushNotificationJob::class,
+				$this->callback(static function (array $arg): bool {
+					return $arg['userId'] === 'erika'
+						&& $arg['subject'] === 'punch_pause_reminder'
+						&& ($arg['params']['maxPause'] ?? null) === 60;
+				})
+			);
+
+		$punch = new ActivePunch();
+		$punch->setId(3);
+		$punch->setEmployeeId(7);
+
+		$this->service->notifyPunchPauseTooLong($punch, new \DateTime('2026-08-24 12:00:00'), 60);
 	}
 
 	private function stubEmployeeWithoutSupervisor(): void {

--- a/tests/Unit/Notification/PushDeliveryTest.php
+++ b/tests/Unit/Notification/PushDeliveryTest.php
@@ -100,13 +100,72 @@ class PushDeliveryTest extends TestCase {
 		$this->assertSame('time_entries_submitted', $captured['data']['type']);
 	}
 
-	public function testUnknownSubjectIsNotPushed(): void {
-		$this->apnsClient->expects($this->never())->method('sendToUser');
+	public function testAbsenceApprovedPushesRenderedBody(): void {
+		$captured = null;
+		$this->apnsClient->expects($this->once())
+			->method('sendToUser')
+			->with('erika', $this->callback(function (array $payload) use (&$captured): bool {
+				$captured = $payload;
+				return true;
+			}))
+			->willReturn([]);
 
-		$this->delivery->send('supervisor', 'absence_approved', [
+		$this->delivery->send('erika', 'absence_approved', [
 			'typeName' => 'Urlaub',
 			'startDate' => '01.08.',
 			'endDate' => '05.08.',
+		]);
+
+		$this->assertSame(
+			'Deine Abwesenheit (Urlaub, 01.08. - 05.08.) wurde genehmigt',
+			$captured['aps']['alert']['body']
+		);
+		$this->assertSame('absence_approved', $captured['data']['type']);
+	}
+
+	public function testTimeEntriesRejectedPushesRenderedBody(): void {
+		$captured = null;
+		$this->apnsClient->expects($this->once())
+			->method('sendToUser')
+			->with('erika', $this->callback(function (array $payload) use (&$captured): bool {
+				$captured = $payload;
+				return true;
+			}))
+			->willReturn([]);
+
+		$this->delivery->send('erika', 'time_entries_rejected', ['month' => 8, 'year' => 2026]);
+
+		$this->assertStringStartsWith('Deine Zeiteinträge für ', $captured['aps']['alert']['body']);
+		$this->assertStringEndsWith(' wurden abgelehnt', $captured['aps']['alert']['body']);
+	}
+
+	public function testPunchReminderPushesRenderedBody(): void {
+		$captured = null;
+		$this->apnsClient->expects($this->once())
+			->method('sendToUser')
+			->with('erika', $this->callback(function (array $payload) use (&$captured): bool {
+				$captured = $payload;
+				return true;
+			}))
+			->willReturn([]);
+
+		$this->delivery->send('erika', 'punch_out_reminder', ['hours' => 10]);
+
+		$this->assertSame(
+			'Du bist seit über 10 Stunden eingestempelt. Nicht vergessen auszustempeln.',
+			$captured['aps']['alert']['body']
+		);
+		$this->assertSame('punch_out_reminder', $captured['data']['type']);
+	}
+
+	public function testUnknownSubjectIsNotPushed(): void {
+		$this->apnsClient->expects($this->never())->method('sendToUser');
+
+		// archive_failed is an in-app-only notification with no mobile push.
+		$this->delivery->send('supervisor', 'archive_failed', [
+			'employeeName' => 'Bob Doe',
+			'month' => 8,
+			'year' => 2026,
 		]);
 	}
 

--- a/tests/Unit/Notification/PushDeliveryTest.php
+++ b/tests/Unit/Notification/PushDeliveryTest.php
@@ -15,12 +15,13 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * Genehmigungs-Push (#593 Phase B, worktime-mobile#19).
+ * Genehmigungs-Push (#593 Phase B/C, worktime-mobile#19).
  *
- * PushDelivery mirrors the two "submitted" in-app notifications to an APNs push.
- * Two things matter and are pinned here: the body is rendered in the recipient's
- * language with the same wording as the in-app Notifier, and a push must never
- * throw — the in-app notification has already gone out.
+ * PushDelivery mirrors the "submitted", "approved"/"rejected" and stopwatch
+ * reminder in-app notifications to an APNs push. Two things matter and are
+ * pinned here: the body is rendered in the recipient's language with the same
+ * wording as the in-app Notifier, and a push must never throw — the in-app
+ * notification has already gone out.
  */
 class PushDeliveryTest extends TestCase {
 


### PR DESCRIPTION
## Was

Erweitert den in Phase B gebauten Push-Weg (`queuePush` → `PushNotificationJob`, QueuedJob außerhalb des Request-Pfads) auf die übrigen **bereits serverseitig existierenden** Benachrichtigungen, damit sie auch auf dem Handy ankommen.

- **Genehmigungs-Entscheidungen** → Push an den Mitarbeiter: `absence_approved`, `absence_rejected`, `time_entries_approved`, `time_entries_rejected`.
- **Stoppuhr-Reminder (#588)** → Push an den Mitarbeiter: `punch_pause_reminder`, `punch_out_reminder` (der `PunchReminderJob` läuft serverseitig seit 0.16.4).

`PushDelivery` rendert die sechs Subjects **wortgleich zum `Notifier`**; die Strings existieren bereits übersetzt in `l10n` → **keine neuen Keys**.

## Prämissen-Korrektur (Design-Runde)

Die ursprüngliche „Phase C" sah einen **Server-Cron für die Tageserinnerung** („heute nichts erfasst") vor. Beim Lesen der Spec zeigte sich: **worktime-mobile#47 ist CLOSED** und wurde bewusst **rein lokal auf dem Gerät** gelöst (`flutter_local_notifications`, wörtlich „kein Server, kein APNs"). Ein Server-Cron würde diese Entscheidung duplizieren → **bewusst nicht gebaut**. `time_entries_reopened` bleibt vorerst In-App-only.

## Tests

- `PushDeliveryTest` — Entscheidungen (approved/rejected) + Punch-Reminder gerendert; `archive_failed` bleibt push-los.
- `NotificationServiceTest` — Entscheidungs- und Reminder-Enqueue an den richtigen Empfänger.
- **429 Unit-Tests grün**, mutationsverifiziert (alle vier `queuePush`-Pfade). DI + Enqueue + Render im NC-Container geprüft. l10n `✓ keine Drift`.

Teil von #593 (Phase B/C-Abschluss) — Sammel-Issue bleibt offen für den echten `.p8`/Geräte-Push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)