### PR TITLE
ci: nc-app-tooling v1.12.0 — Schema- und Notification-Check (nc-app-tooling#11)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Abhaengigkeiten installieren
         run: npm ci
 
+      - name: Schema-Portabilitaet
+        run: npx nc-schema-check
+
+      - name: Notification-Vertraege
+        run: npx nc-notification-check
+
       - name: ESLint
         run: npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "babel-jest": "^29.7.0",
                 "eslint": "^8.57.0",
                 "jest": "^29.7.0",
-                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.11.0",
+                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.12.0",
                 "vue-loader": "^17.4.2",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^6.0.1"
@@ -13261,15 +13261,17 @@
             "license": "MIT"
         },
         "node_modules/nc-app-tooling": {
-            "version": "1.11.0",
-            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#331f81df99bbd11f6f352fbcdfb8a87c48cfc9ec",
+            "version": "1.12.0",
+            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#9864fa3ae8067f75128b2142370bd2cad8afe804",
             "dev": true,
             "license": "AGPL-3.0-or-later",
             "bin": {
                 "nc-bundle-fresh": "bin/bundle-fresh.mjs",
                 "nc-l10n-check": "bin/l10n-check.mjs",
+                "nc-notification-check": "bin/notification-check.mjs",
                 "nc-pre-commit": "bin/pre-commit.mjs",
-                "nc-release-check": "bin/release-check.mjs"
+                "nc-release-check": "bin/release-check.mjs",
+                "nc-schema-check": "bin/schema-check.mjs"
             },
             "engines": {
                 "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "babel-jest": "^29.7.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
-        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.11.0",
+        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.12.0",
         "vue-loader": "^17.4.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^6.0.1"


### PR DESCRIPTION
Rollout aus nc-app-tooling#11: die beiden neuen Pruefer (#7 nc-schema-check, #8 nc-notification-check) als CI-Schritte, nc-app-tooling auf `v1.12.0` gehoben.

## Lokaler Lauf (v1.12.0)
```
✓ nc-schema-check: Schema ist portabel (31 Migrationen, 14 neue Tabellen, 155 Spalten).
✓ nc-notification-check: Setter-Vertraege eingehalten (3 Dateien, 25 Setter-Aufrufe).
```

Der Pre-Commit-Riegel (nc-pre-commit, Pruefungen 5 und 6) kommt mit dem Bump von selbst mit — kein eigener CI-Schritt noetig.