### PR TITLE
chore(deps): nc-app-tooling auf v1.13.0 (nc-appstore-token)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "babel-jest": "^29.7.0",
                 "eslint": "^8.57.0",
                 "jest": "^29.7.0",
-                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.12.0",
+                "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.13.0",
                 "vue-loader": "^17.4.2",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^6.0.1"
@@ -13261,11 +13261,12 @@
             "license": "MIT"
         },
         "node_modules/nc-app-tooling": {
-            "version": "1.12.0",
-            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#9864fa3ae8067f75128b2142370bd2cad8afe804",
+            "version": "1.13.0",
+            "resolved": "git+ssh://git@github.com/cpcMomentum/nc-app-tooling.git#b5cb0dae6dd3898ccb86204eed8609f3c826ed7a",
             "dev": true,
             "license": "AGPL-3.0-or-later",
             "bin": {
+                "nc-appstore-token": "bin/appstore-token.mjs",
                 "nc-bundle-fresh": "bin/bundle-fresh.mjs",
                 "nc-l10n-check": "bin/l10n-check.mjs",
                 "nc-notification-check": "bin/notification-check.mjs",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "babel-jest": "^29.7.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
-        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.12.0",
+        "nc-app-tooling": "github:cpcMomentum/nc-app-tooling#v1.13.0",
         "vue-loader": "^17.4.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^6.0.1"


### PR DESCRIPTION
Reiner Pin-Bump v1.12.0 → v1.13.0. Bringt den Token-Resolver `nc-appstore-token` (nc-app-tooling#12) mit, den der Release-Skill (Schritt 8.2) nutzt. Keine Workflow-Änderung — der Resolver läuft beim Release, nicht in der CI.