### PR TITLE
fix(vacation): Urlaubsanspruch bei Mitte-Jahr-Eintritt nicht mehr aufblähen (#629)

### DIFF
--- a/lib/Service/WorkScheduleService.php
+++ b/lib/Service/WorkScheduleService.php
@@ -85,9 +85,11 @@ class WorkScheduleService {
      * this, the overview would show 40h/30 until the entry date is reached and the
      * employee could appear to have more leave than they do.
      *
-     * Display only: the calculation paths (buildSegments, calculateTargetMinutes)
-     * keep using getScheduleForDate() unchanged, so Soll and entitlement - which
-     * already clip by entry/exit date elsewhere - are untouched.
+     * Display only: getScheduleForDate() itself is unchanged. buildSegments()
+     * (used by calculateTargetMinutes/countWorkingDays/entitlement) has its own
+     * gap-fill (#629): it extends the earliest known profile backward instead of
+     * using the synthetic default, so it no longer matches getScheduleForDate()
+     * for dates before the first profile either.
      */
     public function getDisplaySchedule(int $employeeId): WorkSchedule {
         try {

--- a/lib/Service/WorkScheduleService.php
+++ b/lib/Service/WorkScheduleService.php
@@ -588,8 +588,15 @@ class WorkScheduleService {
             $gapEnd = clone $schedules[0]->getValidFrom();
             $gapEnd->modify('-1 day');
             if ($gapEnd >= $start) {
-                // Use fallback schedule for dates before the first schedule
-                $fallback = $this->getScheduleForDate($employeeId, $start);
+                // #629: extend the earliest real profile back over the gap, NOT the
+                // synthetic 40h/30-day default from getScheduleForDate(). The only
+                // caller that reaches this gap is the full-year entitlement
+                // (getVacationEntitlementForYear scans Jan-Dec); for a mid-year hire
+                // the 30-day default inflated the pro-rata sum and rounded the
+                // entitlement up by a day (nils: 28 -> 28.66 -> 29). The Soll paths
+                // clip their range to the entry date before calling and never reach
+                // here. $schedules is ordered by valid_from ASC, so [0] is earliest.
+                $fallback = $schedules[0];
                 array_unshift($segments, [
                     'schedule' => $fallback,
                     'start' => clone $start,

--- a/tests/Unit/Service/WorkScheduleServiceTest.php
+++ b/tests/Unit/Service/WorkScheduleServiceTest.php
@@ -140,6 +140,27 @@ class WorkScheduleServiceTest extends TestCase {
         $this->assertSame(30, $this->service->getVacationDaysForYear(1, $pastYear));
     }
 
+    /**
+     * #629: a single profile that starts mid-year (e.g. a new hire on 1 May with
+     * a 28-day profile). The months before it have no profile; buildSegments must
+     * extend that same profile back over the gap, NOT the synthetic 30-day
+     * default. Otherwise the pro-rata sum (30 in the gap, 28 for the rest) lands
+     * around 28.66 and rounds the entitlement up to a wrong 29. The uniform
+     * profile must yield exactly its own full-year value.
+     */
+    public function testMidYearSingleProfileNotInflatedByGapDefault(): void {
+        $pastYear = (int)(new DateTime())->format('Y') - 1;
+        // No profile exists before valid_from, mirroring reality — so the old code
+        // fell through to the synthetic 30-day default here.
+        $this->mapper->method('findForDate')
+            ->willThrowException(new DoesNotExistException('before first profile'));
+        $this->mapper->method('findByEmployeeAndDateRange')
+            ->willReturn([$this->scheduleAt($pastYear . '-05-01', 28, 5)]);
+
+        $this->assertSame(28.0, $this->service->getVacationEntitlementForYear(1, $pastYear));
+        $this->assertSame(28, $this->service->getVacationDaysForYear(1, $pastYear));
+    }
+
     // ---------------------------------------------------------------------
     // #581: Anzeige-Profil bei zukünftigem Eintrittsdatum
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Problem (gemeldet von @nilsdohms, #629)

Der angezeigte Urlaubsanspruch war bei einem Mitarbeiter mit Mitte-Jahr-Eintritt um einen Tag zu hoch (29 statt 28). Nils hat sauber belegt: beide `vacation_days`-Spalten stehen auf 28, die 29 wird nie gespeichert — ein reiner Laufzeit-Rechenfehler.

## RCA (dreifach verifiziert: Code, Arithmetik, Live-Endpunkt)

Der Anspruch wird zeitabschnittsweise übers Jahr summiert (`getVacationEntitlementForYear`, #571). Für die Monate **vor dem ersten Arbeitszeitprofil** baute `buildSegments` ein Lücken-Segment über `getScheduleForDate()`, das für Daten vor jedem `valid_from` ein **synthetisches Default mit 30 Urlaubstagen / 8h** liefert.

Nils: Profil ab 01.05. mit 28 Tagen, Lücke Jan–Apr bekam 30:
`(30 × 86 Arbeitstage + 28 × 175) / 261 = 28,66 → round = 29`.

## Fix

Das Lücken-Segment nutzt jetzt das **früheste echte Profil** (`schedules[0]`, per `valid_from ASC` sortiert) statt des 30-Tage-Defaults. Das 30-Default bleibt für wirklich profillose Mitarbeiter (eigener `empty($schedules)`-Zweig).

**Blast-Radius (verifiziert):** Die Lücke wird nur von der Jahres-Anspruchsrechnung erreicht. Die Soll-Pfade (`calculateTargetMinutes`/`countWorkingDays`) kappen ihren Bereich in `OvertimeCalculationService` vorher aufs Eintrittsdatum und erreichen die Lücke nie; `getScheduleForDate` selbst bleibt unangetastet (PDF, Tagesstunden, Sync unberührt).

## Tests

- Neuer Unit-Test (Mitte-Jahr-Profil 28 → Anspruch exakt 28), **mutationsverifiziert** (ohne Fix: 28,66 → 29).
- Volle Unit-Suite grün (478).
- Live auf Dev-Instanz reproduziert: `entitlement` 29 → 28.

Fixes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)
