### PR TITLE
chore(deps): Dependabot zaehmen — keine Major-PRs mehr (#394-Rollout)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
-# Dependabot-Konfiguration — flottenweit vereinheitlicht (nc-app-tooling#13).
+# Dependabot-Konfiguration — flottenweit vereinheitlicht (nc-app-tooling#13),
+# inkl. Major-Suppression aus contractmanager#394.
 #
 # Vorlage ist rechnungswerks Fassung (eingefuehrt 07.08.2026), die sich in der
-# Flotte bewaehrt hat. #13 ("automatisierte Nextcloud-Versionsanpassung") ist
-# im Testpfad bereits geloest: alle Apps leiten die getesteten nextcloud/ocp-
-# Versionen aus info.xml ab (worktime#21) und der canary laeuft gegen
-# dev-master. Was fehlte, war das laufende Nachziehen der Abhaengigkeiten selbst
-# — dafuer sorgt Dependabot hier, inkl. nextcloud/ocp (composer).
+# Flotte bewaehrt hat. Alle Apps leiten die getesteten nextcloud/ocp-Versionen
+# aus info.xml ab (worktime#21), der canary laeuft gegen dev-master. Das
+# laufende Nachziehen der Abhaengigkeiten selbst besorgt Dependabot hier, inkl.
+# nextcloud/ocp (composer).
 #
 # WARUM target-branch develop: Ohne diese Angabe zielen geplante Updates auf den
 # Standard-Branch (main). main bekommt aber nur Releases, gesammelt wird auf
@@ -17,11 +17,18 @@
 # entnehmen; nach derzeitigem Stand zielen sie weiter auf main. Solche PRs
 # werden wie bisher von Hand nach develop uebernommen.
 #
-# WARUM nur minor/patch gruppiert: Ohne Gruppierung entsteht pro Paket ein
-# eigener PR. Major-Spruenge bleiben bewusst einzeln — ein @nextcloud/vue- oder
-# vue-loader-Major kann den Build brechen (Vue-2-Apps) und gehoert einzeln
-# geprueft, nicht in einem Sammel-PR versteckt. Jeder PR durchlaeuft ohnehin die
-# CI samt Build- und Bundle-Frische-Pruefung; ein brechender Bump wird dort rot.
+# WARUM nur minor/patch gruppiert, keine Majors: Ohne Gruppierung entsteht pro
+# Paket ein eigener PR; minor/patch werden daher gebuendelt. Major-Spruenge
+# werden bewusst NICHT mehr als PR geoeffnet (ignore-Block unten) — sie
+# betreffen bei uns fast nur Dev-Werkzeug (eslint/vite/typescript) oder
+# Vue-3-only-Libs (pinia, vue-router) auf Vue-2-Apps, bringen der App keinen
+# Nutzen und kosten nur Zeit. Ein gewuenschter Major wird bei Bedarf von Hand
+# angestossen.
+#
+# WICHTIG — Sicherheit bleibt: Der ignore-Block betrifft nur die geplanten
+# Versionsupdates. Sicherheits-Alerts (Security-Tab) feuern unabhaengig von
+# dieser Datei weiter und werden von Hand behoben. Sicherheitsfixes sind zudem
+# meist patch/minor innerhalb des aktuellen Majors und laufen ohnehin durch.
 
 version: 2
 
@@ -38,6 +45,12 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # Keine Major-Versionsupdates als PR (nur Dev-Werkzeug/Vue-3-Libs, kein
+      # App-Nutzen). Security-Alerts bleiben davon unberuehrt (siehe Kopf).
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
     commit-message:
       prefix: chore(deps)
       prefix-development: chore(deps-dev)
@@ -54,6 +67,11 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # Keine Major-Versionsupdates als PR (Security-Alerts bleiben unberuehrt).
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
     commit-message:
       prefix: chore(deps)
       prefix-development: chore(deps-dev)


### PR DESCRIPTION
Rollt die Major-Suppression aus `contractmanager#394` auf diese App aus — Teil der flottenweiten Vereinheitlichung (nc-app-tooling#13).

**Was:** neuer `ignore`-Block für `version-update:semver-major` bei **npm + composer**. Damit kommen keine Major-Versionsupdates mehr als PR (bei uns fast nur Dev-Werkzeug wie eslint/vite/typescript oder Vue-3-only-Libs wie pinia/vue-router auf Vue-2-Apps — kein App-Nutzen).

**Unberührt:**
- minor/patch laufen weiter gebündelt wie bisher
- `github-actions`-Updates bleiben offen (dort waren die Majors harmlos)
- **Security-Alerts** feuern unabhängig von dieser Datei weiter und werden von Hand behoben

Ein gewünschter Major wird bei Bedarf manuell angestoßen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
